### PR TITLE
Blur and wait in e2e test

### DIFF
--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -127,7 +127,10 @@ AND
 GROUP BY 1 
 ORDER BY 1 
 `);
-            e2eSelectors.RefreshPicker.runButton().first().click({ force: true });
+            // blur and wait for loading
+            cy.get('.panel-content').click();
+            cy.get('.panel-loading');
+            cy.get('.panel-loading', { timeout: 10000 }).should('not.exist');
           },
         });
 


### PR DESCRIPTION
Rather than clicking on the reload button (that may re-request the query and cause errors), blur the editor and wait for the loading animation to disappear.

This should help with #59 ?