### PR TITLE
Do not add quotes for template variables with just one value

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -29,9 +29,6 @@ export class DataSource extends DataSourceWithBackend<AthenaQuery, AthenaDataSou
 
   private interpolateVariable = (value: string | string[]) => {
     if (typeof value === 'string') {
-      if (isNaN(parseInt(value, 10))) {
-        return this.quoteLiteral(value);
-      }
       return value;
     }
 


### PR DESCRIPTION
Context here: https://github.com/grafana/athena-datasource/pull/34#discussion_r698465813

> In the unlikelihood someone wants to use template variables to replace tables for example, they can always use template variable regex field to remove the single quotes.

I actually need to use template variables to resolve a table for a curated dashboard :sweat_smile:. This is because the name of the table is not fixed for the CUR data source for Athena. This is my variable definition:

![Screenshot from 2021-10-01 17-19-18](https://user-images.githubusercontent.com/4025665/135645963-13c50ec6-dc5f-45d1-9290-e74e035d8b03.png)

And this is how I am using it:

![Screenshot from 2021-10-01 17-19-41](https://user-images.githubusercontent.com/4025665/135645999-a6af4f0f-eba7-498e-9aab-d076ea0e7b30.png)

the problem is that it gets substituted to `from 'table_name'` which is not a valid syntax. As far as I can tell, I cannot use the regex to remove the quotes (since the original content doesn't have it). Maybe I am missing something? In any case, I think that quotes are not necessary if the variable is a single value.