### PR TITLE
Return an empty list of columns if the table is not set

### DIFF
--- a/pkg/athena/datasource.go
+++ b/pkg/athena/datasource.go
@@ -199,7 +199,7 @@ func (s *AthenaDatasource) Columns(ctx context.Context, table string) ([]string,
 
 func (s *AthenaDatasource) ColumnsWithConnectionDetails(ctx context.Context, region string, catalog string, database string, table string) ([]string, error) {
 	if table == "" {
-		return nil, nil
+		return []string{}, nil
 	}
 
 	api, err := s.getApi(ctx, region, catalog)

--- a/pkg/athena/datasource_test.go
+++ b/pkg/athena/datasource_test.go
@@ -1,6 +1,7 @@
 package athena
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -121,4 +122,17 @@ func TestConnection_athenaSettingsAndKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConnection_ColumnsWithConnectionDetails(t *testing.T) {
+	t.Run("it should return an empty list if the table is not set", func(t *testing.T) {
+		ds := AthenaDatasource{}
+		tables, err := ds.ColumnsWithConnectionDetails(context.TODO(), "us-east1", "cat", "db", "")
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+		if tables == nil {
+			t.Errorf("unexpected null result")
+		}
+	})
 }


### PR DESCRIPTION
Fixes #70 

The API should return an valid list or an error