### PR TITLE
Stop cancelled requests

### DIFF
--- a/pkg/athena/api/mock/athena-client.go
+++ b/pkg/athena/api/mock/athena-client.go
@@ -22,6 +22,7 @@ type MockAthenaClient struct {
 	Workgroups           []string
 	TableMetadataList    []string
 	Columns              []string
+	Cancelled            bool
 	athenaiface.AthenaAPI
 }
 
@@ -171,4 +172,9 @@ func (m *MockAthenaClient) GetTableMetadataWithContext(ctx aws.Context, input *a
 		r.TableMetadata.Columns = append(r.TableMetadata.Columns, &athena.Column{Name: aws.String(c)})
 	}
 	return r, nil
+}
+
+func (m *MockAthenaClient) StopQueryExecution(input *athena.StopQueryExecutionInput) (*athena.StopQueryExecutionOutput, error) {
+	m.Cancelled = true
+	return &athena.StopQueryExecutionOutput{}, nil
 }


### PR DESCRIPTION
Fixes #64 

We are getting the cancellation event so we just need to stop the query if needed.

@sunker you mentioned to also add a button in the query editor in case the spinner is not explicit enough. That has the problem that the plugin SDK doesn't expose an endpoint or a function to cancel a request. The frontend doesn't have the query ID either (and I see no way to return it before the result of the query) so we cannot implement a specific endpoint for that ourselves. WDYT?