### PR TITLE
chore: fix bug label for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report a bug you found when using this plugin
-labels: datasource/Athena, type/bug
+labels: ["datasource/Athena", "type/bug"]
 ---
 
 <!--


### PR DESCRIPTION
Looks like the syntax for the label isn't right (https://github.com/grafana/grafana/blob/main/.github/ISSUE_TEMPLATE/1-bug_report.md). Not sure how it works for the Grafana repo (maybe they have a separate workflow for the labels?) but looks like this syntax will fix it for our external plugins.

**Before:**
Adding a bug report won't attach a label to the issue.

**After:**
Adding a bug report will attach the labels `datasource/Athena` and `type/bug` to the issue.