### PR TITLE
Use default value if missing

### DIFF
--- a/pkg/athena/driver/rows.go
+++ b/pkg/athena/driver/rows.go
@@ -18,6 +18,8 @@ type Rows struct {
 
 func NewRows(ctx context.Context, athenaAPI athenaiface.AthenaAPI, queryID string) (*Rows, error) {
 	config := drv.NewNoOpsConfig()
+	config.SetMissingAsEmptyString(false)
+	config.SetMissingAsDefault(true)
 	tracer := drv.NewNoOpsObservability()
 	rows, err := drv.NewRows(ctx, athenaAPI, queryID, config, tracer)
 	if err != nil {


### PR DESCRIPTION
Fixes #85 

The problem in #85 is that the table contains columns that the ingested data does not. For example, the table defines the column:

```
CREATE EXTERNAL TABLE vpclogs (
...
  `tcp_flags` int, 
...
)
```

`tcp_flags` is supposed to be a numeric value, but if the data does not contain that value, the golang driver for Athena returns a `* string` with `nil` value. The problem comes later, when trying to convert a `* string` to an `int`, the plugin fails. To avoid this, it's possible to configure the driver to return the "zero" value of the type in that situation. That means, that `tcp_flags` will be set to 0 if the value is missing:

![Screenshot from 2021-11-22 15-58-51](https://user-images.githubusercontent.com/4025665/142885744-ec3bf65f-b67e-4b89-bea9-d21ff7f08ba7.png)

## Additional notes

Another option to solve this issue would be to ignore the column type and parse the value based on the type of the value (`* string`). The problem with that is that it's only possible to set **one** type per column. This means that in case that the table contains  `tcp_flags` just sometimes, all of them would be set to strings rather than numeric outputs, which is also wrong.

cc/ @mhausenblas