### PR TITLE
docs(datasource-provisioning): Include example with Datasource API

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,29 @@ datasources:
       defaultRegion: eu-west-2
 ```
 
+### Complete configuration using Grafana's [Datasource API](https://grafana.com/docs/grafana/latest/http_api/data_source/#create-a-data-source)
+```json
+{
+  "name": "Amazon Athena",
+  "type": "grafana-athena-datasource",
+  "typeName": "Amazon Athena",
+  "access": "proxy",
+  "basicAuth": false,
+  "isDefault": true,
+  "jsonData": {
+    "assumeRoleArn": "arn:aws:iam::111111111111:role/test-role",
+    "authType": "default",
+    "catalog": "AwsDataCatalog",
+    "database": "test-database",
+    "defaultRegion": "eu-west-1",
+    "endpoint": "https://test",
+    "externalId": "external",
+    "outputLocation": "s3://test-bucket",
+    "workgroup": "test-workgroup"
+  }
+}
+```
+
 ### Acknowledgment
 
 The backend driver is based on the implementation of [uber/athenadriver](https://github.com/uber/athenadriver), which provides a fully-featured driver for AWS Athena.


### PR DESCRIPTION
#### Description

I was having some trouble trying to configure Athena Datasource through Grafana's Datasource API.

I think some examples has some inconsistency because if I execute the following `cULR` request I obtain the following information.
`$ curl http://127.0.0.1:3000/api/datasources -H "Authorization: Basic YWRtaW46YWRtaW4=`
```json
[
  {
    "id": 2,
    "uid": "CM1GXc1nk",
    "orgId": 1,
    "name": "Amazon Athena",
    "type": "grafana-athena-datasource",
    "typeName": "Amazon Athena",
    "typeLogoUrl": "public/plugins/grafana-athena-datasource/img/logo.svg",
    "access": "proxy",
    "url": "",
    "password": "",
    "user": "",
    "database": "",
    "basicAuth": false,
    "isDefault": true,
    "jsonData": {
      "assumeRoleArn": "arn:aws:iam::111111111111:role/test-role",
      "authType": "default",
      "catalog": "AwsDataCatalog",
      "database": "test-database",
      "defaultRegion": "eu-west-2",
      "endpoint": "https://test-endpoint",
      "externalId": "external",
      "outputLocation": "s3://test-bucket",
      "workgroup": "test-workgroup"
    },
    "readOnly": false
  }
]
```

And the above result differs from the example configuration.

Am I missing something?

Please, change whatever is necessary.

Thank you.