### PR TITLE
Update aws-sdk version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.37.32
 	github.com/google/go-cmp v0.5.6
-	github.com/grafana/grafana-aws-sdk v0.8.0
+	github.com/grafana/grafana-aws-sdk v0.9.0
 	github.com/grafana/grafana-plugin-sdk-go v0.114.0
 	github.com/grafana/sqlds/v2 v2.3.3
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.37.32
 	github.com/google/go-cmp v0.5.6
-	github.com/grafana/grafana-aws-sdk v0.9.0
+	github.com/grafana/grafana-aws-sdk v0.9.1
 	github.com/grafana/grafana-plugin-sdk-go v0.114.0
 	github.com/grafana/sqlds/v2 v2.3.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-aws-sdk v0.8.0 h1:Q0t6szK5sSTzoY8MgYF0+FHt6BTb8+8pYto3GPxREo8=
-github.com/grafana/grafana-aws-sdk v0.8.0/go.mod h1:NFffX96sJCXNrZsA3ag7Y9nHOFOMMQqmCnGmuSgwb0E=
+github.com/grafana/grafana-aws-sdk v0.9.0 h1:oAEpSlNaD09S25F2TX8WwxCwnKk/ModUh0Uxgl+NP6M=
+github.com/grafana/grafana-aws-sdk v0.9.0/go.mod h1:6KaQ8uUD4KpXr/b7bAC7zbfSXTVOiTk4XhIrwkGWn4w=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0 h1:9I55IXw7mOT71tZ/pdqCaWGz8vxfz31CXjaDtBV9ZBo=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-aws-sdk v0.9.0 h1:oAEpSlNaD09S25F2TX8WwxCwnKk/ModUh0Uxgl+NP6M=
-github.com/grafana/grafana-aws-sdk v0.9.0/go.mod h1:6KaQ8uUD4KpXr/b7bAC7zbfSXTVOiTk4XhIrwkGWn4w=
+github.com/grafana/grafana-aws-sdk v0.9.1 h1:jMZlsLsWnqOwLt2UNcLUsJ2z6289hLYlscK35QgS158=
+github.com/grafana/grafana-aws-sdk v0.9.1/go.mod h1:6KaQ8uUD4KpXr/b7bAC7zbfSXTVOiTk4XhIrwkGWn4w=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0 h1:9I55IXw7mOT71tZ/pdqCaWGz8vxfz31CXjaDtBV9ZBo=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -22,11 +22,14 @@ type API struct {
 
 func New(sessionCache *awsds.SessionCache, settings sqlModels.Settings) (api.AWSAPI, error) {
 	athenaSettings := settings.(*models.AthenaDataSourceSettings)
-	sess, err := awsds.GetSessionWithDefaultRegion(sessionCache, athenaSettings.AWSDatasourceSettings)
+	sess, err := sessionCache.GetSession(awsds.SessionConfig{
+		Settings:      athenaSettings.AWSDatasourceSettings,
+		Config:        athenaSettings.Config,
+		UserAgentName: aws.String("Athena"),
+	})
 	if err != nil {
 		return nil, err
 	}
-	awsds.WithUserAgent(sess, "Athena")
 
 	return &API{Client: athena.New(sess), settings: athenaSettings}, nil
 }

--- a/pkg/athena/models/settings.go
+++ b/pkg/athena/models/settings.go
@@ -12,6 +12,7 @@ import (
 
 type AthenaDataSourceSettings struct {
 	awsds.AWSDatasourceSettings
+	Config         backend.DataSourceInstanceSettings
 	Database       string `json:"Database"`
 	Catalog        string `json:"Catalog"`
 	WorkGroup      string `json:"WorkGroup"`
@@ -31,6 +32,8 @@ func (s *AthenaDataSourceSettings) Load(config backend.DataSourceInstanceSetting
 
 	s.AccessKey = config.DecryptedSecureJSONData["accessKey"]
 	s.SecretKey = config.DecryptedSecureJSONData["secretKey"]
+
+	s.Config = config
 
 	return nil
 }


### PR DESCRIPTION
Ref [#39089](https://github.com/grafana/grafana/issues/39089)

Update `grafana-aws-sdk` to use the backend HTTP client provider.

