### PR TITLE
chore: add to GH Projects automatically

### DIFF
--- a/.github/issue_commands.json
+++ b/.github/issue_commands.json
@@ -1,6 +1,14 @@
 [   
     {
       "type": "label",
+      "name": "datasource/Athena",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/97"
+      }
+    },
+    {
+      "type": "label",
       "name": "type/docs",
       "action": "addToProject",
       "addToProject": {


### PR DESCRIPTION
Currently, we automatically add the label `datasource/*` to new issues.
This PR uses the existing GH action already set up to additionally add them to our GH Projects board.

Ideally, this should be done without relying on the `datasource/*` label (since now we have two places where the label is defined: `issue_commands.json` and `1-bug_report.md`) but can use what we have in place for now and come up with another way of doing this later.