### PR TITLE
Plugin.json : Updated grafana dependency to >=8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-
 ## 2.0.0
 _Not released yet_
 
 - Breaking Change: Athena plugin now requires Grafana 8.0+ to run.
+
 ## 1.0.5
 
 - Fixes a bug that caused invalid tokens when assuming a role in private clouds (e.g. `gov`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 2.0.0
+_Not released yet_
+
+- Breaking Change: Athena plugin now requires Grafana 8.0+ to run.
 ## 1.0.5
 
 - Fixes a bug that caused invalid tokens when assuming a role in private clouds (e.g. `gov`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Changelog
 
 ## 2.0.0
-_Not released yet_
 
-- Breaking Change: Athena plugin now requires Grafana 8.0+ to run.
+- Stopping support for Grafana versions under `8.0.0` .
 
 ## 1.0.5
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -46,7 +46,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=7.5.0",
+    "grafanaDependency": ">=8.0.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
Part of https://github.com/grafana/cloud-data-sources/issues/9

> We only want to support the two last major versions of Grafana, so we should update all our plugins so that they specify the minimum grafana version to be >=8.0.0. Releases of these plugins should be synced with grana 9.0.0 stable release (could be a few days after).