### PR TITLE
Interpolate query properties with variables only if property is set

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -134,6 +134,14 @@ describe('AthenaDatasource', () => {
       expect(queries[0]).toBe(defaultQuery);
     });
 
+    it('should not add additional properties to the query', async () => {
+      const request = { ...queryRequest, targets: [{ ...defaultQuery, column: undefined }] };
+      const queries = ctx.ds.buildQuery(request, request.targets);
+
+      expect(queries).toHaveLength(1);
+      expect(queries[0]).toEqual({ ...defaultQuery, column: undefined });
+    });
+
     it('should return query with template variables replaced', async () => {
       queryRequest.targets = [
         {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -68,8 +68,8 @@ export class DataSource extends DatasourceWithAsyncBackend<AthenaQuery, AthenaDa
       query.connectionArgs.region = this.templateSrv.replace(query.connectionArgs.region, options.scopedVars);
       query.connectionArgs.catalog = this.templateSrv.replace(query.connectionArgs.catalog, options.scopedVars);
       query.connectionArgs.database = this.templateSrv.replace(query.connectionArgs.database, options.scopedVars);
-      query.table = this.templateSrv.replace(query.table, options.scopedVars);
-      query.column = this.templateSrv.replace(query.column, options.scopedVars);
+      query.table = query.table ? this.templateSrv.replace(query.table, options.scopedVars) : undefined;
+      query.column = query.column ? this.templateSrv.replace(query.column, options.scopedVars) : undefined;
       return query;
     });
 


### PR DESCRIPTION
Fixes: #192

Queries were not being cancelled when the stop button was pressed. The query was being updated with an empty property when interpolating variables. In-flight queries are kept in a map where the stringified query is used as a key to identify it. When the empty interpolated variable was added to the query, it would cause the key change. E.g. a query `{ table: "table_name" }` would be changed to `{ table: "table_name", column: "" }` (`column` is empty but an property is still added to the query).