### PR TITLE
Hide run buttons in annotations

### DIFF
--- a/src/AnnotationQueryEditor.tsx
+++ b/src/AnnotationQueryEditor.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { AthenaQuery, AthenaDataSourceOptions } from './types';
+import { QueryEditorProps } from '@grafana/data';
+import { DataSource } from 'datasource';
+import { QueryEditor } from 'QueryEditor';
+
+export function AnnotationQueryEditor(props: QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions>) {
+  return <QueryEditor {...props} hideOptions hideRunQueryButtons />;
+}

--- a/src/annotationSupport.ts
+++ b/src/annotationSupport.ts
@@ -1,0 +1,5 @@
+import { AnnotationQueryEditor } from './AnnotationQueryEditor';
+
+export const annotationSupport = {
+  QueryEditor: AnnotationQueryEditor,
+};

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -6,6 +6,7 @@ import { filterSQLQuery, applySQLTemplateVariables } from '@grafana/aws-sdk';
 import { DatasourceWithAsyncBackend } from '@grafana/async-query-data';
 import { Observable } from 'rxjs';
 import { cloneDeep } from 'lodash';
+import { annotationSupport } from './annotationSupport';
 
 export class DataSource extends DatasourceWithAsyncBackend<AthenaQuery, AthenaDataSourceOptions> {
   defaultRegion = '';
@@ -23,8 +24,7 @@ export class DataSource extends DatasourceWithAsyncBackend<AthenaQuery, AthenaDa
     this.variables = new AthenaVariableSupport(this);
   }
 
-  // This will support annotation queries for 7.2+
-  annotations = {};
+  annotations = annotationSupport;
 
   filterQuery(target: AthenaQuery) {
     return target.hide !== true && filterSQLQuery(target);


### PR DESCRIPTION
Same as [here](https://github.com/grafana/redshift-datasource/pull/206)
In annotations editor we have 3 ways to run a query - with the buttons "Run" and "Cancel", the TEST button, as well as onBlur. This removes the extra buttons, the same as in the Athena variable editor.

Before:
<img width="500" alt="Screen Shot 2023-01-31 at 9 31 06 AM" src="https://user-images.githubusercontent.com/16140639/215708916-7cad1d0f-6a4e-4667-bb99-4c32f42ddce1.png">

After: 
<img width="500" alt="Screen Shot 2023-01-31 at 9 34 07 AM" src="https://user-images.githubusercontent.com/16140639/215709222-103b8fb2-946b-4dc3-abb4-94604af511dc.png">

