### PR TITLE
Add Query Result Reuse Support to Backend

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -45,6 +45,7 @@
     "sqlds",
     "sqlutil",
     "starttime",
+    "stretchr",
     "sunker",
     "iwysiu",
     "idastambuk",

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ require (
 	github.com/aws/aws-sdk-go v1.44.189
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.8
-	github.com/grafana/grafana-aws-sdk v0.12.0
+	github.com/grafana/grafana-aws-sdk v0.13.0
 	github.com/grafana/grafana-plugin-sdk-go v0.139.0
 	github.com/grafana/sqlds/v2 v2.3.10
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.2
 	github.com/uber/athenadriver v1.1.14-0.20210910155546-e1e4a4cd6895
 	github.com/viant/toolbox v0.34.5
 	gotest.tools v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-aws-sdk v0.12.0 h1:eUjFdFZeZE+nyu/RMRz+qFxTBew69ToLBrbRhTbjkfM=
-github.com/grafana/grafana-aws-sdk v0.12.0/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
+github.com/grafana/grafana-aws-sdk v0.13.0 h1:v6oGsdbGXMLD6f4soPOCWd7ya2n5TE1Vtbl1/mhP90E=
+github.com/grafana/grafana-aws-sdk v0.13.0/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.134.0/go.mod h1:jmrxelOJKrIK0yrsIzcotS8pbqPZozbmJgGy7k3hK1k=
 github.com/grafana/grafana-plugin-sdk-go v0.139.0 h1:2RQKM2QpSaWTtaGN6sK+R7LO7zykOeTYF0QkAMA7JsI=

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
-	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/athena"
@@ -17,11 +15,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/sqlds/v2"
-)
-
-const (
-	engineVersionExpr                        = `^Athena engine version (?P<Version>\d+)$`
-	resultReuseMinimumSupportedEngineVersion = 3
 )
 
 type API struct {
@@ -318,16 +311,5 @@ func (c *API) Columns(ctx aws.Context, options sqlds.Options) ([]string, error) 
 }
 
 func workgroupEngineSupportsResultReuse(version string) bool {
-	r, _ := regexp.Compile(engineVersionExpr)
-	matches := r.FindStringSubmatch(version)
-	if len(matches) == 0 {
-		return false
-	}
-
-	engineVersion, err := strconv.ParseInt(matches[r.SubexpIndex("Version")], 10, 64)
-	if err != nil {
-		return false
-	}
-
-	return engineVersion >= resultReuseMinimumSupportedEngineVersion
+	return version != "Athena engine version 2"
 }

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -255,7 +255,7 @@ func (c *API) Workgroups(ctx context.Context) ([]string, error) {
 	return res, nil
 }
 
-func (c *API) Workgroup(ctx context.Context, options sqlds.Options) (string, error) {
+func (c *API) WorkgroupEngineVersion(ctx context.Context, options sqlds.Options) (string, error) {
 	workgroup := c.getOptionWithDefault(options, "workgroup")
 	out, err := c.Client.GetWorkGroupWithContext(ctx, &athena.GetWorkGroupInput{
 		WorkGroup: aws.String(workgroup),

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -57,6 +57,12 @@ func (c *API) Execute(ctx context.Context, input *api.ExecuteQueryInput) (*api.E
 			Database: aws.String(c.settings.Database),
 		},
 		WorkGroup: aws.String(c.settings.WorkGroup),
+		ResultReuseConfiguration: &athena.ResultReuseConfiguration{
+			ResultReuseByAgeConfiguration: &athena.ResultReuseByAgeConfiguration{
+				Enabled:         aws.Bool(c.settings.ResultReuseEnabled),
+				MaxAgeInMinutes: aws.Int64(c.settings.ResultReuseMaxAgeInMinutes),
+			},
+		},
 	}
 
 	if c.settings.OutputLocation != "" {

--- a/pkg/athena/api/api_test.go
+++ b/pkg/athena/api/api_test.go
@@ -102,6 +102,18 @@ func TestConnection_ListWorkgroups(t *testing.T) {
 	}
 }
 
+func TestConnection_GetWorkgroupVersion(t *testing.T) {
+	expected := "Athena engine version 3"
+	c := &API{Client: &athenaclientmock.MockAthenaClient{WorkgroupEngineVersion: expected}}
+	res, err := c.WorkgroupEngineVersion(context.TODO(), sqlds.Options{"workgroup": "workgroup"})
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if !cmp.Equal(expected, res) {
+		t.Errorf("unexpected result: %v", cmp.Diff(expected, res))
+	}
+}
+
 func TestConnection_ListTables(t *testing.T) {
 	expected := []string{"foo"}
 	c := &API{Client: &athenaclientmock.MockAthenaClient{TableMetadataList: expected}}

--- a/pkg/athena/api/api_test.go
+++ b/pkg/athena/api/api_test.go
@@ -146,3 +146,11 @@ func TestConnection_ListColumnsForTable(t *testing.T) {
 		t.Errorf("unexpected result: %v", cmp.Diff(expected, res))
 	}
 }
+
+func Test_WorkgroupEngineSupportsResultReuse(t *testing.T) {
+	assert.True(t, workgroupEngineSupportsResultReuse("Athena engine version 3"))
+
+	assert.False(t, workgroupEngineSupportsResultReuse("Athena engine version 1"))
+	assert.False(t, workgroupEngineSupportsResultReuse("Athena engine version 2"))
+	assert.False(t, workgroupEngineSupportsResultReuse("some random string"))
+}

--- a/pkg/athena/api/api_test.go
+++ b/pkg/athena/api/api_test.go
@@ -149,8 +149,5 @@ func TestConnection_ListColumnsForTable(t *testing.T) {
 
 func Test_WorkgroupEngineSupportsResultReuse(t *testing.T) {
 	assert.True(t, workgroupEngineSupportsResultReuse("Athena engine version 3"))
-
-	assert.False(t, workgroupEngineSupportsResultReuse("Athena engine version 1"))
 	assert.False(t, workgroupEngineSupportsResultReuse("Athena engine version 2"))
-	assert.False(t, workgroupEngineSupportsResultReuse("some random string"))
 }

--- a/pkg/athena/api/api_test.go
+++ b/pkg/athena/api/api_test.go
@@ -9,18 +9,23 @@ import (
 	"github.com/grafana/athena-datasource/pkg/athena/models"
 	"github.com/grafana/grafana-aws-sdk/pkg/sql/api"
 	"github.com/grafana/sqlds/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConnection_Execute(t *testing.T) {
 	expectedID := "foo"
 	c := NewFake(&athenaclientmock.MockAthenaClient{}, &models.AthenaDataSourceSettings{})
 	out, err := c.Execute(context.TODO(), &api.ExecuteQueryInput{Query: expectedID})
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-	if out.ID != expectedID {
-		t.Errorf("unexpected result: %v", cmp.Diff(out.ID, expectedID))
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, expectedID, out.ID)
+}
+
+func TestConnection_Execute_ResultReuseNotEnabledAndMaxAgeInMinutesProvidedDoesNotThrowError(t *testing.T) {
+	expectedID := "foo"
+	c := NewFake(&athenaclientmock.MockAthenaClient{}, &models.AthenaDataSourceSettings{ResultReuseEnabled: false, ResultReuseMaxAgeInMinutes: 60})
+	out, err := c.Execute(context.TODO(), &api.ExecuteQueryInput{Query: expectedID})
+	assert.Nil(t, err)
+	assert.Equal(t, expectedID, out.ID)
 }
 
 func Test_Status(t *testing.T) {

--- a/pkg/athena/api/mock/athena-client.go
+++ b/pkg/athena/api/mock/athena-client.go
@@ -15,14 +15,15 @@ const DESCRIBE_STATEMENT_SUCCEEDED = "DESCRIBE_STATEMENT_FINISHED"
 
 // Define a mock struct to be used in your unit tests of myFunc.
 type MockAthenaClient struct {
-	CalledTimesCounter   int
-	CalledTimesCountDown int
-	Catalogs             []string
-	Databases            []string
-	Workgroups           []string
-	TableMetadataList    []string
-	Columns              []string
-	Cancelled            bool
+	CalledTimesCounter     int
+	CalledTimesCountDown   int
+	Catalogs               []string
+	Databases              []string
+	Workgroups             []string
+	WorkgroupEngineVersion string
+	TableMetadataList      []string
+	Columns                []string
+	Cancelled              bool
 	athenaiface.AthenaAPI
 }
 
@@ -53,6 +54,20 @@ func (m *MockAthenaClient) GetQueryExecutionWithContext(ctx aws.Context, input *
 				State: aws.String(athena.QueryExecutionStateRunning),
 			},
 		}
+	}
+	return output, nil
+}
+
+func (m *MockAthenaClient) GetWorkGroupWithContext(ctx aws.Context, input *athena.GetWorkGroupInput, opts ...request.Option) (*athena.GetWorkGroupOutput, error) {
+	output := &athena.GetWorkGroupOutput{
+		WorkGroup: &athena.WorkGroup{
+			Configuration: &athena.WorkGroupConfiguration{
+				EngineVersion: &athena.EngineVersion{
+					EffectiveEngineVersion: aws.String(m.WorkgroupEngineVersion),
+					SelectedEngineVersion:  aws.String(m.WorkgroupEngineVersion),
+				},
+			},
+		},
 	}
 	return output, nil
 }

--- a/pkg/athena/datasource.go
+++ b/pkg/athena/datasource.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/grafana/athena-datasource/pkg/athena/api"
 	"github.com/grafana/athena-datasource/pkg/athena/driver"
@@ -162,19 +161,6 @@ func (s *AthenaDatasource) Workgroups(ctx context.Context, options sqlds.Options
 	return api.Workgroups(ctx)
 }
 
-func toString(value interface{}) string {
-	switch v := value.(type) {
-	case string:
-		return v
-	case bool:
-		return strconv.FormatBool(v)
-	case float64:
-		return strconv.FormatFloat(v, 'f', -1, 64)
-	default:
-		return ""
-	}
-}
-
 func parseArgs(queryArgs json.RawMessage) (sqlds.Options, error) {
 	args := map[string]interface{}{}
 	if queryArgs != nil {
@@ -186,7 +172,7 @@ func parseArgs(queryArgs json.RawMessage) (sqlds.Options, error) {
 
 	options := sqlds.Options{}
 	for k, v := range args {
-		options[k] = toString(v)
+		options[k] = fmt.Sprintf("%v", v)
 	}
 
 	return options, nil

--- a/pkg/athena/datasource.go
+++ b/pkg/athena/datasource.go
@@ -79,7 +79,6 @@ func (s *AthenaDatasource) Connect(config backend.DataSourceInstanceSettings, qu
 }
 
 func (s *AthenaDatasource) GetAsyncDB(config backend.DataSourceInstanceSettings, queryArgs json.RawMessage) (awsds.AsyncDB, error) {
-	backend.Logger.Debug("GetAsyncDB", "queryArgs", queryArgs)
 	s.awsDS.Init(config)
 	args, err := parseArgs(queryArgs)
 	if err != nil {
@@ -186,10 +185,20 @@ func parseArgs(queryArgs json.RawMessage) (sqlds.Options, error) {
 		}
 	}
 	options := sqlds.Options{}
-	options[models.Region] = args.Region
-	options[models.Catalog] = args.Catalog
-	options[models.Database] = args.Database
-	options[models.ResultReuseEnabled] = fmt.Sprintf("%t", args.ResultReuseEnabled)
-	options[models.ResultReuseMaxAgeInMinutes] = fmt.Sprintf("%d", args.ResultReuseMaxAgeInMinutes)
+	if args.Region != "" {
+		options[models.Region] = args.Region
+	}
+	if args.Catalog != "" {
+		options[models.Catalog] = args.Catalog
+	}
+	if args.Database != "" {
+		options[models.Database] = args.Database
+	}
+	if args.ResultReuseEnabled {
+		options[models.ResultReuseEnabled] = fmt.Sprintf("%t", args.ResultReuseEnabled)
+	}
+	if args.ResultReuseMaxAgeInMinutes > 0 {
+		options[models.ResultReuseMaxAgeInMinutes] = fmt.Sprintf("%d", args.ResultReuseMaxAgeInMinutes)
+	}
 	return options, nil
 }

--- a/pkg/athena/datasource_test.go
+++ b/pkg/athena/datasource_test.go
@@ -14,7 +14,7 @@ import (
 	sqlModels "github.com/grafana/grafana-aws-sdk/pkg/sql/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/sqlds/v2"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockClient struct {
@@ -72,16 +72,8 @@ func TestConnection(t *testing.T) {
 		fakeQueryArgs := json.RawMessage(`{"resultReuseEnabled": true}`)
 		_, err := ds.GetAsyncDB(fakeConfig, fakeQueryArgs)
 
-		if err != nil {
-			t.Errorf("unexpected err, %v", err)
-		}
-		if resultReuseEnabled, ok := mc.wasCalledWith["resultReuseEnabled"]; resultReuseEnabled != "true" {
-			if !ok {
-				t.Errorf("no resultReuseEnabled found")
-			} else {
-				t.Errorf("unexpected resultReuseEnabled %v", mc.wasCalledWith["resultReuseEnabled"])
-			}
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, "true", mc.wasCalledWith["resultReuseEnabled"])
 	})
 
 	t.Run("it should call getAsyncDB with the resultReuseMaxAgeInMinutes option if one is provided", func(t *testing.T) {

--- a/pkg/athena/datasource_test.go
+++ b/pkg/athena/datasource_test.go
@@ -48,16 +48,8 @@ func TestConnection(t *testing.T) {
 		fakeQueryArgs := json.RawMessage(`{"test": "thing", "region": ""}`)
 		_, err := ds.Connect(fakeConfig, fakeQueryArgs)
 
-		if err != nil {
-			t.Errorf("unexpected err, %v", err)
-		}
-		if region, ok := mc.wasCalledWith["region"]; region != "__default" {
-			if !ok {
-				t.Errorf("no region found")
-			} else {
-				t.Errorf("unexpected region %v", mc.wasCalledWith["region"])
-			}
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, "__default", mc.wasCalledWith["region"])
 	})
 
 	t.Run("it should call getAsyncDB with the resultReuseEnabled option if one is provided", func(t *testing.T) {
@@ -88,16 +80,8 @@ func TestConnection(t *testing.T) {
 		fakeQueryArgs := json.RawMessage(`{"resultReuseMaxAgeInMinutes": 10}`)
 		_, err := ds.GetAsyncDB(fakeConfig, fakeQueryArgs)
 
-		if err != nil {
-			t.Errorf("unexpected err, %v", err)
-		}
-		if resultReuseMaxAgeInMinutes, ok := mc.wasCalledWith["resultReuseMaxAgeInMinutes"]; resultReuseMaxAgeInMinutes != "10" {
-			if !ok {
-				t.Errorf("no resultReuseMaxAgeInMinutes found")
-			} else {
-				t.Errorf("unexpected resultReuseMaxAgeInMinutes %v", mc.wasCalledWith["resultReuseMaxAgeInMinutes"])
-			}
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, "10", mc.wasCalledWith["resultReuseMaxAgeInMinutes"])
 	})
 }
 
@@ -110,12 +94,8 @@ func TestColumns(t *testing.T) {
 			"database": "db",
 			"table":    "",
 		})
-		if err != nil {
-			t.Errorf("unexpected error %v", err)
-		}
-		if tables == nil {
-			t.Errorf("unexpected null result")
-		}
+		assert.Nil(t, err)
+		assert.NotNil(t, tables)
 	})
 
 	t.Run("it should call getAPI with the region passed in from args", func(t *testing.T) {
@@ -131,14 +111,6 @@ func TestColumns(t *testing.T) {
 		})
 
 		assert.Error(t, err, "fake api error", "unexpected error: %v", err)
-
-		if region, ok := mc.wasCalledWith["region"]; region != "us-east1" {
-			if !ok {
-				t.Errorf("no region found")
-			} else {
-				t.Errorf("unexpected region %v", mc.wasCalledWith["region"])
-			}
-		}
-
+		assert.Equal(t, "us-east1", mc.wasCalledWith["region"])
 	})
 }

--- a/pkg/athena/datasource_test.go
+++ b/pkg/athena/datasource_test.go
@@ -58,7 +58,54 @@ func TestConnection(t *testing.T) {
 				t.Errorf("unexpected region %v", mc.wasCalledWith["region"])
 			}
 		}
+	})
 
+	t.Run("it should call getAsyncDB with the resultReuseEnabled option if one is provided", func(t *testing.T) {
+		mc := mockClient{}
+		ds := AthenaDatasource{
+			awsDS: &mc,
+		}
+
+		fakeConfig := backend.DataSourceInstanceSettings{
+			JSONData: json.RawMessage{},
+		}
+		fakeQueryArgs := json.RawMessage(`{"resultReuseEnabled": true}`)
+		_, err := ds.GetAsyncDB(fakeConfig, fakeQueryArgs)
+
+		if err != nil {
+			t.Errorf("unexpected err, %v", err)
+		}
+		if resultReuseEnabled, ok := mc.wasCalledWith["resultReuseEnabled"]; resultReuseEnabled != "true" {
+			if !ok {
+				t.Errorf("no resultReuseEnabled found")
+			} else {
+				t.Errorf("unexpected resultReuseEnabled %v", mc.wasCalledWith["resultReuseEnabled"])
+			}
+		}
+	})
+
+	t.Run("it should call getAsyncDB with the resultReuseMaxAgeInMinutes option if one is provided", func(t *testing.T) {
+		mc := mockClient{}
+		ds := AthenaDatasource{
+			awsDS: &mc,
+		}
+
+		fakeConfig := backend.DataSourceInstanceSettings{
+			JSONData: json.RawMessage{},
+		}
+		fakeQueryArgs := json.RawMessage(`{"resultReuseMaxAgeInMinutes": 10}`)
+		_, err := ds.GetAsyncDB(fakeConfig, fakeQueryArgs)
+
+		if err != nil {
+			t.Errorf("unexpected err, %v", err)
+		}
+		if resultReuseMaxAgeInMinutes, ok := mc.wasCalledWith["resultReuseMaxAgeInMinutes"]; resultReuseMaxAgeInMinutes != "10" {
+			if !ok {
+				t.Errorf("no resultReuseMaxAgeInMinutes found")
+			} else {
+				t.Errorf("unexpected resultReuseMaxAgeInMinutes %v", mc.wasCalledWith["resultReuseMaxAgeInMinutes"])
+			}
+		}
 	})
 }
 

--- a/pkg/athena/fake/datasource.go
+++ b/pkg/athena/fake/datasource.go
@@ -17,6 +17,7 @@ type AthenaFakeDatasource struct {
 	Resources map[string]map[string][]string
 	// regions -> workgroups
 	Wg              map[string][]string
+	WgEngineVersion map[string]string
 	ExistingTables  map[string]map[string]map[string][]string
 	ExistingColumns map[string]map[string]map[string]map[string][]string
 }
@@ -82,6 +83,14 @@ func (s *AthenaFakeDatasource) Workgroups(ctx context.Context, options sqlds.Opt
 		return nil, fmt.Errorf("missing region %s", region)
 	}
 	return s.Wg[region], nil
+}
+
+func (s *AthenaFakeDatasource) WorkgroupEngineVersion(ctx context.Context, options sqlds.Options) (string, error) {
+	workgroup := options["workgroup"]
+	if _, exists := s.WgEngineVersion[workgroup]; !exists {
+		return "", fmt.Errorf("missing workgroup %s", workgroup)
+	}
+	return s.WgEngineVersion[workgroup], nil
 }
 
 func (s *AthenaFakeDatasource) Tables(ctx context.Context, options sqlds.Options) ([]string, error) {

--- a/pkg/athena/models/settings.go
+++ b/pkg/athena/models/settings.go
@@ -12,13 +12,11 @@ import (
 )
 
 const (
-	defaultResultReuseEnabled         = false
-	defaultResultReuseMaxAgeInMinutes = int64(60)
-	Region                            = "region"
-	Database                          = "database"
-	Catalog                           = "catalog"
-	ResultReuseEnabled                = "resultReuseEnabled"
-	ResultReuseMaxAgeInMinutes        = "resultReuseMaxAgeInMinutes"
+	Region                     = "region"
+	Database                   = "database"
+	Catalog                    = "catalog"
+	ResultReuseEnabled         = "resultReuseEnabled"
+	ResultReuseMaxAgeInMinutes = "resultReuseMaxAgeInMinutes"
 )
 
 type AthenaDataSourceSettings struct {
@@ -69,16 +67,12 @@ func (s *AthenaDataSourceSettings) Apply(args sqlds.Options) {
 		s.Database = database
 	}
 
-	if resultReuseEnabled, err := strconv.ParseBool(resultReuseEnabledString); err != nil {
-		s.ResultReuseEnabled = defaultResultReuseEnabled
-	} else {
+	if resultReuseEnabled, err := strconv.ParseBool(resultReuseEnabledString); err == nil {
 		s.ResultReuseEnabled = resultReuseEnabled
 	}
 
 	if s.ResultReuseEnabled {
-		if resultReuseMaxAgeInMinutes, err := strconv.ParseInt(resultReuseMaxAgeInMinutesString, 10, 64); err != nil {
-			s.ResultReuseMaxAgeInMinutes = defaultResultReuseMaxAgeInMinutes
-		} else {
+		if resultReuseMaxAgeInMinutes, err := strconv.ParseInt(resultReuseMaxAgeInMinutesString, 10, 64); err == nil {
 			s.ResultReuseMaxAgeInMinutes = resultReuseMaxAgeInMinutes
 		}
 	}

--- a/pkg/athena/models/settings.go
+++ b/pkg/athena/models/settings.go
@@ -11,9 +11,14 @@ import (
 	"github.com/grafana/sqlds/v2"
 )
 
-var (
+const (
 	defaultResultReuseEnabled         = false
 	defaultResultReuseMaxAgeInMinutes = int64(60)
+	Region                            = "region"
+	Database                          = "database"
+	Catalog                           = "catalog"
+	ResultReuseEnabled                = "resultReuseEnabled"
+	ResultReuseMaxAgeInMinutes        = "resultReuseMaxAgeInMinutes"
 )
 
 type AthenaDataSourceSettings struct {
@@ -47,7 +52,7 @@ func (s *AthenaDataSourceSettings) Load(config backend.DataSourceInstanceSetting
 }
 
 func (s *AthenaDataSourceSettings) Apply(args sqlds.Options) {
-	region, catalog, database, resultReuseEnabledString, resultReuseMaxAgeInMinutesString := args["region"], args["catalog"], args["database"], args["resultReuseEnabled"], args["resultReuseMaxAgeInMinutes"]
+	region, catalog, database, resultReuseEnabledString, resultReuseMaxAgeInMinutesString := args[Region], args[Catalog], args[Database], args[ResultReuseEnabled], args[ResultReuseMaxAgeInMinutes]
 	if region != "" {
 		if region == models.DefaultKey {
 			s.Region = s.DefaultRegion

--- a/pkg/athena/models/settings_test.go
+++ b/pkg/athena/models/settings_test.go
@@ -113,7 +113,7 @@ func TestConnection_getRegionKey(t *testing.T) {
 			},
 		},
 		{
-			description: "result reuse optons set to unknown values",
+			description: "result reuse options set to unknown values",
 			settings:    &AthenaDataSourceSettings{},
 			options:     sqlds.Options{"resultReuseEnabled": "true_blah_blah", "resultReuseMaxAgeInMinutes": "10_not_a_number"},
 			expected: AthenaDataSourceSettings{

--- a/pkg/athena/models/settings_test.go
+++ b/pkg/athena/models/settings_test.go
@@ -86,6 +86,48 @@ func TestConnection_getRegionKey(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "undefined result reuse",
+			settings:    &AthenaDataSourceSettings{},
+			options:     sqlds.Options{},
+			expected: AthenaDataSourceSettings{
+				ResultReuseEnabled: false,
+			},
+		},
+		{
+			description: "result reuse enabled without max age value set uses default max age value",
+			settings:    &AthenaDataSourceSettings{},
+			options:     sqlds.Options{"resultReuseEnabled": "true"},
+			expected: AthenaDataSourceSettings{
+				ResultReuseEnabled:         true,
+				ResultReuseMaxAgeInMinutes: 60,
+			},
+		},
+		{
+			description: "result reuse enabled and max age value set",
+			settings:    &AthenaDataSourceSettings{},
+			options:     sqlds.Options{"resultReuseEnabled": "true", "resultReuseMaxAgeInMinutes": "10"},
+			expected: AthenaDataSourceSettings{
+				ResultReuseEnabled:         true,
+				ResultReuseMaxAgeInMinutes: 10,
+			},
+		},
+		{
+			description: "result reuse optons set to unknown values",
+			settings:    &AthenaDataSourceSettings{},
+			options:     sqlds.Options{"resultReuseEnabled": "true_blah_blah", "resultReuseMaxAgeInMinutes": "10_not_a_number"},
+			expected: AthenaDataSourceSettings{
+				ResultReuseEnabled: false,
+			},
+		},
+		{
+			description: "result reuse is disabled and max age value is set",
+			settings:    &AthenaDataSourceSettings{},
+			options:     sqlds.Options{"resultReuseEnabled": "false", "resultReuseMaxAgeInMinutes": "10"},
+			expected: AthenaDataSourceSettings{
+				ResultReuseEnabled: false,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {

--- a/pkg/athena/models/settings_test.go
+++ b/pkg/athena/models/settings_test.go
@@ -95,15 +95,6 @@ func TestConnection_getRegionKey(t *testing.T) {
 			},
 		},
 		{
-			description: "result reuse enabled without max age value set uses default max age value",
-			settings:    &AthenaDataSourceSettings{},
-			options:     sqlds.Options{"resultReuseEnabled": "true"},
-			expected: AthenaDataSourceSettings{
-				ResultReuseEnabled:         true,
-				ResultReuseMaxAgeInMinutes: 60,
-			},
-		},
-		{
 			description: "result reuse enabled and max age value set",
 			settings:    &AthenaDataSourceSettings{},
 			options:     sqlds.Options{"resultReuseEnabled": "true", "resultReuseMaxAgeInMinutes": "10"},

--- a/pkg/athena/routes/routes.go
+++ b/pkg/athena/routes/routes.go
@@ -38,9 +38,21 @@ func (r *AthenaResourceHandler) workgroups(rw http.ResponseWriter, req *http.Req
 	routes.SendResources(rw, res, err)
 }
 
+func (r *(AthenaResourceHandler)) workgroupEngineVersion(rw http.ResponseWriter, req *http.Request) {
+	reqBody, err := routes.ParseBody(req.Body)
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		routes.Write(rw, []byte(err.Error()))
+		return
+	}
+	res, err := r.athena.WorkgroupEngineVersion(req.Context(), reqBody)
+	routes.SendResources(rw, res, err)
+}
+
 func (r *AthenaResourceHandler) Routes() map[string]func(http.ResponseWriter, *http.Request) {
 	routes := r.DefaultRoutes()
 	routes["/catalogs"] = r.catalogs
 	routes["/workgroups"] = r.workgroups
+	routes["/workgroupEngineVersion"] = r.workgroupEngineVersion
 	return routes
 }

--- a/pkg/athena/routes/routes_test.go
+++ b/pkg/athena/routes/routes_test.go
@@ -20,6 +20,9 @@ var ds = &fake.AthenaFakeDatasource{
 	Wg: map[string][]string{
 		"us-east-2": {"wg1", "wg2"},
 	},
+	WgEngineVersion: map[string]string{
+		"wg1": "Athena engine version 3",
+	},
 	ExistingTables: map[string]map[string]map[string][]string{
 		"us-east-2": {
 			"catalog": {
@@ -108,6 +111,19 @@ func TestRoutes(t *testing.T) {
 			description:  "wrong region for workgroups",
 			route:        "/workgroups",
 			reqBody:      []byte(`{"region":"us-east-3"}`),
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			description:    "workgroup engine version",
+			route:          "/workgroupEngineVersion",
+			reqBody:        []byte(`{"workgroup":"wg1"}`),
+			expectedCode:   http.StatusOK,
+			expectedResult: `"Athena engine version 3"`,
+		},
+		{
+			description:  "workgroup engine version missing workgroup",
+			route:        "/workgroupEngineVersion",
+			reqBody:      []byte{},
 			expectedCode: http.StatusBadRequest,
 		},
 	}


### PR DESCRIPTION
Adds backend support for query result reuse.

This depends on https://github.com/grafana/grafana-aws-sdk/pull/71

Fixes: https://github.com/grafana/oss-plugin-partnerships/issues/120

This uses the connection args to set the result reuse configuration. The connection args are per query. The connection args are passed into the `Connect` method for sync queries (this is done in sqlds https://github.com/grafana/sqlds/blob/f35c5a62f66c02aef63b260c1e0a25568ae698b6/datasource.go#L169), and are passed into the `GetAsyncDB` method for async queries (this will be done in grafana-aws-sdk in this PR https://github.com/grafana/grafana-aws-sdk/pull/71/files).

`Connect` and `GetAsyncDB` eventually call [`Settings.Apply`](https://github.com/grafana/grafana-aws-sdk/blob/fdb2a182c315dedb479698d4fdeb0f5af235e2b8/pkg/sql/datasource/datasource.go#L116) which is defined in `pkg/athena/models/settings.go` below. This applies the Result Reuse Configuration to the settings that is used in the `Execute` method in `pkg/athena/api/api.go`

The frontend will update the `AthenaQuery` type to include `resultReuseEnabled` and `resultReuseMaxAgeInMinutes` in `connectionArgs` here https://github.com/grafana/athena-datasource/blob/3b0518bf118910644c84082c03d222862f83133d/src/types.ts#L27-L31.