### PR TITLE
Add result reuse options to query editor

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,10 +1,26 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { config } from '@grafana/runtime';
+<<<<<<< HEAD
 import { QueryEditorProps } from '@grafana/data';
 import { AthenaDataSourceOptions, AthenaQuery } from './types';
 import { DataSource } from './datasource';
 import { QueryEditorForm } from './QueryEditorForm';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
+||||||| parent of cca27f8 (update import)
+import { FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
+import { RunQueryButtons } from '@grafana/async-query-data';
+import { selectors } from 'tests/selectors';
+import { appendTemplateVariables } from 'utils';
+import SQLEditor from 'SQLEditor';
+import { ResultReuse } from 'ResultReuse/ResultReuse';
+=======
+import { FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
+import { RunQueryButtons } from '@grafana/async-query-data';
+import { selectors } from 'tests/selectors';
+import { appendTemplateVariables } from 'utils';
+import SQLEditor from 'SQLEditor';
+import { ResultReuse } from 'ResultReuse';
+>>>>>>> cca27f8 (update import)
 
 export function QueryEditor(props: QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions>) {
   const [dataIsStale, setDataIsStale] = useState(false);

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,26 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { config } from '@grafana/runtime';
-<<<<<<< HEAD
 import { QueryEditorProps } from '@grafana/data';
 import { AthenaDataSourceOptions, AthenaQuery } from './types';
 import { DataSource } from './datasource';
 import { QueryEditorForm } from './QueryEditorForm';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
-||||||| parent of cca27f8 (update import)
-import { FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
-import { RunQueryButtons } from '@grafana/async-query-data';
-import { selectors } from 'tests/selectors';
-import { appendTemplateVariables } from 'utils';
-import SQLEditor from 'SQLEditor';
-import { ResultReuse } from 'ResultReuse/ResultReuse';
-=======
-import { FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
-import { RunQueryButtons } from '@grafana/async-query-data';
-import { selectors } from 'tests/selectors';
-import { appendTemplateVariables } from 'utils';
-import SQLEditor from 'SQLEditor';
-import { ResultReuse } from 'ResultReuse';
->>>>>>> cca27f8 (update import)
 
 export function QueryEditor(props: QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions>) {
   const [dataIsStale, setDataIsStale] = useState(false);

--- a/src/QueryEditorForm.test.tsx
+++ b/src/QueryEditorForm.test.tsx
@@ -121,7 +121,10 @@ describe('QueryEditor', () => {
 
     await select(selectEl, 'foo', { container: document.body });
 
-    expect(ds.postResource).toHaveBeenCalledWith('tables', { ...q.connectionArgs });
+    expect(ds.postResource).toHaveBeenCalledWith(
+      'tables',
+      expect.objectContaining({ region: defaultKey, catalog: defaultKey, database: defaultKey })
+    );
     expect(onChange).toHaveBeenCalledWith({
       ...q,
       table: 'foo',
@@ -155,10 +158,10 @@ describe('QueryEditor', () => {
 
     await select(selectEl, 'columnName', { container: document.body });
 
-    expect(ds.postResource).toHaveBeenCalledWith('columns', {
-      ...q.connectionArgs,
-      table: 'tableName',
-    });
+    expect(ds.postResource).toHaveBeenCalledWith(
+      'columns',
+      expect.objectContaining({ region: defaultKey, catalog: defaultKey, database: defaultKey, table: 'tableName' })
+    );
     expect(onChange).toHaveBeenCalledWith({
       ...q,
       column: 'columnName',

--- a/src/QueryEditorForm.tsx
+++ b/src/QueryEditorForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './datasource';
 import { AthenaDataSourceOptions, AthenaQuery, defaultQuery, SelectableFormatOptions } from './types';
@@ -7,6 +7,7 @@ import { FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
 import { selectors } from 'tests/selectors';
 import { appendTemplateVariables } from 'utils';
 import SQLEditor from 'SQLEditor';
+import { ResultReuse } from 'ResultReuse/ResultReuse';
 
 type Props = QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions> & {
   hideOptions?: boolean;
@@ -15,6 +16,13 @@ type Props = QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions> 
 type QueryProperties = 'regions' | 'catalogs' | 'databases' | 'tables' | 'columns';
 
 export function QueryEditorForm(props: Props) {
+  const [resultReuseSupported, setResultReuseSupported] = useState(false);
+  useEffect(() => {
+    const getIsResultReuseSupported = async () => {
+      setResultReuseSupported(await props.datasource.isResultReuseSupported());
+    };
+    getIsResultReuseSupported();
+  }, [props.datasource]);
   const queryWithDefaults = {
     ...defaultQuery,
     ...props.query,
@@ -124,6 +132,7 @@ export function QueryEditorForm(props: Props) {
             labelWidth={11}
             className="width-12"
           />
+          <ResultReuse enabled={resultReuseSupported} query={props.query} onChange={props.onChange} />
           {!props.hideOptions && (
             <>
               <h6>Frames</h6>

--- a/src/ResultReuse/ResultReuse.test.tsx
+++ b/src/ResultReuse/ResultReuse.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ResultReuse } from './ResultReuse';
 import { mockQuery } from '__mocks__/datasource';
 
@@ -20,5 +20,37 @@ describe('ResultReuse', () => {
 
     expect(toggle).toBeDisabled();
     expect(ttlInput).toBeDisabled();
+  });
+
+  it('should call `onChange` when toggle is clicked', () => {
+    const onChange = jest.fn();
+    render(<ResultReuse enabled={true} onChange={onChange} query={mockQuery} />);
+    const toggle = screen.getByLabelText('Enable');
+
+    fireEvent.click(toggle);
+
+    expect(onChange).toBeCalledWith({
+      ...mockQuery,
+      connectionArgs: {
+        ...mockQuery.connectionArgs,
+        resultReuseEnabled: true,
+      },
+    });
+  });
+
+  it('should call `onChange` when TTL input is changed', () => {
+    const onChange = jest.fn();
+    render(<ResultReuse enabled={true} onChange={onChange} query={mockQuery} />);
+    const ttlInput = screen.getByLabelText('TTL (mins)');
+
+    fireEvent.change(ttlInput, { target: { value: '10' } });
+
+    expect(onChange).toBeCalledWith({
+      ...mockQuery,
+      connectionArgs: {
+        ...mockQuery.connectionArgs,
+        resultReuseMaxAgeInMinutes: 10,
+      },
+    });
   });
 });

--- a/src/ResultReuse/ResultReuse.test.tsx
+++ b/src/ResultReuse/ResultReuse.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ResultReuse } from './ResultReuse';
+import { mockQuery } from '__mocks__/datasource';
+
+describe('ResultReuse', () => {
+  it('options should be enabled if `enabled=true`', () => {
+    render(<ResultReuse enabled={true} onChange={() => {}} query={mockQuery} />);
+    const toggle = screen.getByLabelText('Enable');
+    const ttlInput = screen.getByLabelText('TTL (mins)');
+
+    expect(toggle).toBeEnabled();
+    expect(ttlInput).toBeEnabled();
+  });
+
+  it('options should be disabled if `enabled=false`', () => {
+    render(<ResultReuse enabled={false} onChange={() => {}} query={mockQuery} />);
+    const toggle = screen.getByLabelText('Enable');
+    const ttlInput = screen.getByLabelText('TTL (mins)');
+
+    expect(toggle).toBeDisabled();
+    expect(ttlInput).toBeDisabled();
+  });
+});

--- a/src/ResultReuse/ResultReuse.tsx
+++ b/src/ResultReuse/ResultReuse.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Checkbox, InlineField, Input, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { AthenaQuery, DEFAULT_RESULT_REUSE_ENABLED, DEFAULT_RESULT_REUSE_MAX_AGE_IN_MINUTES } from '../types';
+import { GrafanaTheme2 } from '@grafana/data';
+
+interface ResultReuseProps {
+  query: AthenaQuery;
+  enabled?: boolean;
+  onChange: (value: AthenaQuery) => void;
+}
+
+export const ResultReuse = ({ enabled, onChange, query }: ResultReuseProps) => {
+  const {
+    connectionArgs: {
+      resultReuseEnabled = DEFAULT_RESULT_REUSE_ENABLED,
+      resultReuseMaxAgeInMinutes = DEFAULT_RESULT_REUSE_MAX_AGE_IN_MINUTES,
+    } = {},
+  } = query;
+  const styles = useStyles2(getStyles);
+
+  const handleEnabledChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { checked } = e.currentTarget;
+    onChange({
+      ...query,
+      connectionArgs: {
+        ...query.connectionArgs,
+        resultReuseEnabled: checked,
+      },
+    });
+  };
+
+  const handleTTLChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    onChange({
+      ...query,
+      connectionArgs: {
+        ...query.connectionArgs,
+        resultReuseMaxAgeInMinutes: Number(value),
+      },
+    });
+  };
+
+  return (
+    <>
+      <h6>
+        Query result reuse <span className={styles.optional}>(engine version 3 only)</span>
+      </h6>
+      <InlineField labelWidth={11} disabled={!enabled} label="Enable" aria-label="Enable query result reuse">
+        <Checkbox onChange={handleEnabledChange} value={resultReuseEnabled && enabled} />
+      </InlineField>
+      <InlineField labelWidth={11} disabled={!enabled} label="TTL (mins)" aria-label="Max age in minutes">
+        <Input
+          className="width-12"
+          min={0}
+          max={10080}
+          onChange={handleTTLChange}
+          type="number"
+          value={resultReuseMaxAgeInMinutes}
+        />
+      </InlineField>
+    </>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  optional: css({
+    fontSize: 12,
+    fontStyle: 'italic',
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/src/ResultReuse/ResultReuse.tsx
+++ b/src/ResultReuse/ResultReuse.tsx
@@ -32,6 +32,7 @@ export const ResultReuse = ({ enabled, onChange, query }: ResultReuseProps) => {
 
   const handleTTLChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget;
+
     onChange({
       ...query,
       connectionArgs: {
@@ -41,16 +42,25 @@ export const ResultReuse = ({ enabled, onChange, query }: ResultReuseProps) => {
     });
   };
 
+  const invalidResultReuseMaxAgeInMinutes = resultReuseMaxAgeInMinutes < 0 || resultReuseMaxAgeInMinutes > 10080;
+
   return (
     <>
       <h6>Query result reuse {!enabled && <span className={styles.optional}>(engine version 3 only)</span>}</h6>
-      <InlineField labelWidth={11} disabled={!enabled} label="Enable" aria-label="Enable query result reuse">
+      <InlineField labelWidth={13} disabled={!enabled} label="Enable" aria-label="Enable query result reuse">
         <Checkbox id="query-result-reuse-toggle" onChange={handleEnabledChange} value={resultReuseEnabled && enabled} />
       </InlineField>
-      <InlineField labelWidth={11} disabled={!enabled} label="TTL (mins)" aria-label="Max age in minutes">
+      <InlineField
+        labelWidth={13}
+        disabled={!enabled}
+        invalid={invalidResultReuseMaxAgeInMinutes}
+        label="TTL (mins)"
+        aria-label="Max age in minutes"
+        tooltip="The maximum age for reusing query results in minutes. Minimum 0, maximum 10080."
+      >
         <Input
           id="query-result-reuse-ttl"
-          className="width-12"
+          className="width-11"
           min={0}
           max={10080}
           onChange={handleTTLChange}

--- a/src/ResultReuse/ResultReuse.tsx
+++ b/src/ResultReuse/ResultReuse.tsx
@@ -45,14 +45,16 @@ export const ResultReuse = ({ enabled, onChange, query }: ResultReuseProps) => {
     <>
       <h6>Query result reuse {!enabled && <span className={styles.optional}>(engine version 3 only)</span>}</h6>
       <InlineField labelWidth={11} disabled={!enabled} label="Enable" aria-label="Enable query result reuse">
-        <Checkbox onChange={handleEnabledChange} value={resultReuseEnabled && enabled} />
+        <Checkbox id="query-result-reuse-toggle" onChange={handleEnabledChange} value={resultReuseEnabled && enabled} />
       </InlineField>
       <InlineField labelWidth={11} disabled={!enabled} label="TTL (mins)" aria-label="Max age in minutes">
         <Input
+          id="query-result-reuse-ttl"
           className="width-12"
           min={0}
           max={10080}
           onChange={handleTTLChange}
+          onBlur={handleTTLChange}
           type="number"
           value={resultReuseMaxAgeInMinutes}
         />

--- a/src/ResultReuse/ResultReuse.tsx
+++ b/src/ResultReuse/ResultReuse.tsx
@@ -43,9 +43,7 @@ export const ResultReuse = ({ enabled, onChange, query }: ResultReuseProps) => {
 
   return (
     <>
-      <h6>
-        Query result reuse <span className={styles.optional}>(engine version 3 only)</span>
-      </h6>
+      <h6>Query result reuse {!enabled && <span className={styles.optional}>(engine version 3 only)</span>}</h6>
       <InlineField labelWidth={11} disabled={!enabled} label="Enable" aria-label="Enable query result reuse">
         <Checkbox onChange={handleEnabledChange} value={resultReuseEnabled && enabled} />
       </InlineField>

--- a/src/ResultReuse/index.ts
+++ b/src/ResultReuse/index.ts
@@ -1,0 +1,1 @@
+export { ResultReuse } from './ResultReuse';

--- a/src/__mocks__/datasource.ts
+++ b/src/__mocks__/datasource.ts
@@ -1,5 +1,12 @@
 import { DataSourcePluginOptionsEditorProps, PluginType } from '@grafana/data';
-import { AthenaDataSourceOptions, AthenaDataSourceSecureJsonData, AthenaQuery, defaultKey } from '../types';
+import {
+  AthenaDataSourceOptions,
+  AthenaDataSourceSecureJsonData,
+  AthenaQuery,
+  defaultKey,
+  DEFAULT_RESULT_REUSE_ENABLED,
+  DEFAULT_RESULT_REUSE_MAX_AGE_IN_MINUTES,
+} from '../types';
 import { DataSource } from '../datasource';
 
 export const mockDatasourceOptions: DataSourcePluginOptionsEditorProps<
@@ -67,7 +74,13 @@ export const mockDatasource = new DataSource({
 });
 
 export const mockQuery: AthenaQuery = {
-  connectionArgs: { region: defaultKey, catalog: defaultKey, database: defaultKey },
+  connectionArgs: {
+    region: defaultKey,
+    catalog: defaultKey,
+    database: defaultKey,
+    resultReuseEnabled: DEFAULT_RESULT_REUSE_ENABLED,
+    resultReuseMaxAgeInMinutes: DEFAULT_RESULT_REUSE_MAX_AGE_IN_MINUTES,
+  },
   format: 1,
   rawSQL: 'SELECT * FROM table',
   refId: '',

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -43,7 +43,7 @@ export class DataSource extends DatasourceWithAsyncBackend<AthenaQuery, AthenaDa
   }
 
   workgroupEngineSupportsResultReuse(version: string) {
-    return version === 'Athena engine version 3';
+    return version !== 'Athena engine version 2';
   }
 
   annotations = annotationSupport;

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,8 @@ export interface AthenaQuery extends SQLQuery {
     region?: string;
     catalog?: string;
     database?: string;
+    resultReuseEnabled?: boolean;
+    resultReuseMaxAgeInMinutes?: number;
   };
   table?: string;
   column?: string;
@@ -37,6 +39,9 @@ export interface AthenaQuery extends SQLQuery {
 
 export const defaultKey = '__default';
 
+export const DEFAULT_RESULT_REUSE_ENABLED = false;
+export const DEFAULT_RESULT_REUSE_MAX_AGE_IN_MINUTES = 60;
+
 export const defaultQuery: Partial<AthenaQuery> = {
   format: FormatOptions.Table,
   rawSQL: '',
@@ -44,6 +49,8 @@ export const defaultQuery: Partial<AthenaQuery> = {
     region: defaultKey,
     catalog: defaultKey,
     database: defaultKey,
+    resultReuseEnabled: DEFAULT_RESULT_REUSE_ENABLED,
+    resultReuseMaxAgeInMinutes: DEFAULT_RESULT_REUSE_MAX_AGE_IN_MINUTES,
   },
 };
 


### PR DESCRIPTION
Adds a component to the query editor to let the user toggle whether to enable query result reuse and the TTL for reusing query results. If the Athena engine version is 2, then the option is disabled.

Fixes: https://github.com/grafana/oss-plugin-partnerships/issues/121
Fixes: https://github.com/grafana/oss-plugin-partnerships/issues/126

This is a screenshot of the query editor on Athena Engine Version 2 (the reuse result options are disabled and a message is shown to indicate engine version 3 is required for query result reuse)
<img width="849" alt="athena-engine-version-2" src="https://user-images.githubusercontent.com/19530599/221034052-741ae4da-fbc4-43ce-ad43-292948b35464.png">

This is a screenshot of the query editor on Athena Engine Version 3
<img width="849" alt="athena-engine-version-3" src="https://user-images.githubusercontent.com/19530599/221034077-de5fde03-4b53-4f17-a792-e14bfe060469.png">
