### PR TITLE
Feature/editor header

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.0.42",
+    "@grafana/aws-sdk": "0.0.44",
     "@grafana/data": "9.3.2",
     "@grafana/e2e": "9.3.2",
     "@grafana/e2e-selectors": "9.3.2",

--- a/src/AnnotationQueryEditor.tsx
+++ b/src/AnnotationQueryEditor.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { AthenaQuery, AthenaDataSourceOptions } from './types';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from 'datasource';
-import { QueryEditor } from 'QueryEditor';
+import { QueryEditorForm } from './QueryEditorForm';
 
 export function AnnotationQueryEditor(props: QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions>) {
-  return <QueryEditor {...props} hideOptions hideRunQueryButtons />;
+  return <QueryEditorForm {...props} hideOptions />;
 }

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryEditor } from 'QueryEditor';
+import React from 'react';
+import { mockDatasource, mockQuery } from './__mocks__/datasource';
+import * as experimental from '@grafana/experimental';
+import * as runtime from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+
+const ds = mockDatasource;
+const q = { ...mockQuery, rawSQL: '' };
+
+const mockGetVariables = jest.fn().mockReturnValue([]);
+
+jest.spyOn(ds, 'getVariables').mockImplementation(mockGetVariables);
+
+jest.mock('@grafana/experimental', () => ({
+  ...jest.requireActual<typeof experimental>('@grafana/experimental'),
+  SQLEditor: function SQLEditor(props: any) {
+    return (
+      <input {...props} data-testid="codeEditor" onChange={(event: any) => props.onChange(event.target.value)}></input>
+    );
+  },
+}));
+
+const props = {
+  datasource: ds,
+  query: q,
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+};
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual<typeof runtime>('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      athenaAsyncQueryDataSupport: true,
+    },
+  },
+}));
+
+beforeEach(() => {
+  ds.getResource = jest.fn().mockResolvedValue([]);
+  ds.postResource = jest.fn().mockResolvedValue([]);
+});
+
+describe('Query Editor', () => {
+  it('run button should be disabled if the query is empty', () => {
+    render(<QueryEditor {...props} query={{ ...props.query, rawSQL: '' }} />);
+    const runButton = screen.getByRole('button', { name: 'Run query' });
+    expect(runButton).toBeDisabled();
+  });
+  it('should show cancel button if athenaAsyncQueryDataSupport feature is enabled', () => {
+    render(<QueryEditor {...props} />);
+    const cancelButton = screen.getByRole('button', { name: 'Stop query' });
+    expect(cancelButton).toBeInTheDocument();
+  });
+  it('should not show cancel button if athenaAsyncQueryDataSupport feature is disabled', () => {
+    config.featureToggles.athenaAsyncQueryDataSupport = false;
+    render(<QueryEditor {...props} />);
+    const cancelButton = screen.queryByRole('button', { name: 'Stop query' });
+    expect(cancelButton).not.toBeInTheDocument();
+  });
+  it('should re-enable Run query button if there is a change to the query', async () => {
+    render(<QueryEditor {...props} query={{ ...props.query, rawSQL: 'initial query' }} />);
+    const runButton = screen.getByRole('button', { name: 'Run query' });
+    expect(runButton).toBeDisabled();
+
+    const input = screen.getByTestId('codeEditor');
+    expect(input).toBeDefined();
+
+    fireEvent.change(input, { target: { value: 'test query' } });
+
+    expect(props.onChange).toHaveBeenCalledWith({ ...props.query, rawSQL: 'test query' });
+    expect(runButton).not.toBeDisabled();
+  });
+});

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -44,7 +44,7 @@ beforeEach(() => {
 
 describe('Query Editor', () => {
   it('run button should be disabled if the query is empty', () => {
-    render(<QueryEditor {...props} query={{ ...props.query, rawSQL: '' }} />);
+    render(<QueryEditor {...props} />);
     const runButton = screen.getByRole('button', { name: 'Run query' });
     expect(runButton).toBeDisabled();
   });

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,0 +1,38 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { config } from '@grafana/runtime';
+import { QueryEditorProps } from '@grafana/data';
+import { AthenaDataSourceOptions, AthenaQuery } from './types';
+import { DataSource } from './datasource';
+import { QueryEditorForm } from './QueryEditorForm';
+import { QueryEditorHeader } from '@grafana/aws-sdk';
+
+export function QueryEditor(props: QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions>) {
+  const [dataIsStale, setDataIsStale] = useState(false);
+  const { onChange } = props;
+
+  useEffect(() => {
+    setDataIsStale(false);
+  }, [props.data]);
+
+  const onChangeInternal = useCallback(
+    (query: AthenaQuery) => {
+      setDataIsStale(true);
+      onChange(query);
+    },
+    [onChange]
+  );
+
+  return (
+    <>
+      {props?.app !== 'explore' && (
+        <QueryEditorHeader<DataSource, AthenaQuery, AthenaDataSourceOptions>
+          {...props}
+          enableRunButton={dataIsStale && !!props.query.rawSQL}
+          showAsyncQueryButtons={config.featureToggles.athenaAsyncQueryDataSupport}
+          cancel={config.featureToggles.athenaAsyncQueryDataSupport ? props.datasource.cancel : undefined}
+        />
+      )}
+      <QueryEditorForm {...props} onChange={onChangeInternal} />
+    </>
+  );
+}

--- a/src/QueryEditorForm.test.tsx
+++ b/src/QueryEditorForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { QueryEditor } from './QueryEditor';
+import { render, screen } from '@testing-library/react';
+import { QueryEditorForm } from './QueryEditorForm';
 import { mockDatasource, mockQuery } from './__mocks__/datasource';
 import '@testing-library/jest-dom';
 import { select } from 'react-select-event';
@@ -49,7 +49,7 @@ describe('QueryEditor', () => {
     const onChange = jest.fn();
     ds.getResource = jest.fn().mockResolvedValue([ds.defaultRegion, 'foo']);
     ds.getRegions = jest.fn(() => ds.getResource('regions'));
-    render(<QueryEditor {...props} onChange={onChange} />);
+    render(<QueryEditorForm {...props} onChange={onChange} />);
 
     const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.region.input);
     expect(selectEl).toBeInTheDocument();
@@ -67,7 +67,7 @@ describe('QueryEditor', () => {
     const onChange = jest.fn();
     ds.postResource = jest.fn().mockResolvedValue([ds.defaultCatalog, 'foo']);
     ds.getCatalogs = jest.fn((query) => ds.postResource('catalogs', { region: query.connectionArgs.region }));
-    render(<QueryEditor {...props} onChange={onChange} />);
+    render(<QueryEditorForm {...props} onChange={onChange} />);
 
     const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.catalog.input);
     expect(selectEl).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('QueryEditor', () => {
     ds.getDatabases = jest.fn((query) =>
       ds.postResource('databases', { region: query.connectionArgs.region, catalog: query.connectionArgs.catalog })
     );
-    render(<QueryEditor {...props} onChange={onChange} onRunQuery={onRunQuery} />);
+    render(<QueryEditorForm {...props} onChange={onChange} onRunQuery={onRunQuery} />);
 
     const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.database.input);
     expect(selectEl).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('QueryEditor', () => {
         database: query.connectionArgs.database,
       })
     );
-    render(<QueryEditor {...props} onChange={onChange} onRunQuery={onRunQuery} />);
+    render(<QueryEditorForm {...props} onChange={onChange} onRunQuery={onRunQuery} />);
 
     const selectEl = screen.getByLabelText('Table');
     expect(selectEl).toBeInTheDocument();
@@ -142,7 +142,7 @@ describe('QueryEditor', () => {
       })
     );
     render(
-      <QueryEditor
+      <QueryEditorForm
         {...props}
         onChange={onChange}
         onRunQuery={onRunQuery}
@@ -167,36 +167,8 @@ describe('QueryEditor', () => {
     expect(onRunQuery).not.toHaveBeenCalled();
   });
 
-  it('run button should be disabled if the query is not valid', () => {
-    render(<QueryEditor {...props} query={{ ...props.query, rawSQL: '' }} />);
-    const runButton = screen.getByRole('button', { name: 'Run' });
-    expect(runButton).toBeDisabled();
-  });
-
-  it('should run queries when the run button is clicked', () => {
-    const onChange = jest.fn();
-    const onRunQuery = jest.fn();
-    render(<QueryEditor {...props} onRunQuery={onRunQuery} onChange={onChange} />);
-    const runButton = screen.getByRole('button', { name: 'Run' });
-    expect(runButton).toBeInTheDocument();
-
-    expect(onRunQuery).not.toBeCalled();
-    fireEvent.click(runButton);
-    expect(onRunQuery).toBeCalledTimes(1);
-  });
-
-  it('stop button should be disabled until run button is clicked', () => {
-    render(<QueryEditor {...props} />);
-    const runButton = screen.getByRole('button', { name: 'Run' });
-    const stopButton = screen.getByRole('button', { name: 'Stop' });
-    expect(stopButton).toBeInTheDocument();
-    expect(stopButton).toBeDisabled();
-    fireEvent.click(runButton);
-    expect(stopButton).not.toBeDisabled();
-  });
-
   it('should display query options by default', async () => {
-    render(<QueryEditor {...props} />);
+    render(<QueryEditorForm {...props} />);
     const selectEl = screen.getByLabelText('Format as');
     expect(selectEl).toBeInTheDocument();
   });

--- a/src/QueryEditorForm.tsx
+++ b/src/QueryEditorForm.tsx
@@ -3,25 +3,18 @@ import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './datasource';
 import { AthenaDataSourceOptions, AthenaQuery, defaultQuery, SelectableFormatOptions } from './types';
 import { InlineSegmentGroup } from '@grafana/ui';
-import { config } from '@grafana/runtime';
 import { FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
-import { RunQueryButtons } from '@grafana/async-query-data';
 import { selectors } from 'tests/selectors';
 import { appendTemplateVariables } from 'utils';
 import SQLEditor from 'SQLEditor';
 
 type Props = QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions> & {
   hideOptions?: boolean;
-  hideRunQueryButtons?: boolean;
 };
 
 type QueryProperties = 'regions' | 'catalogs' | 'databases' | 'tables' | 'columns';
 
-function isQueryValid(query: AthenaQuery) {
-  return !!query.rawSQL;
-}
-
-export function QueryEditor(props: Props) {
+export function QueryEditorForm(props: Props) {
   const queryWithDefaults = {
     ...defaultQuery,
     ...props.query,
@@ -141,17 +134,6 @@ export function QueryEditor(props: Props) {
 
         <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
           <SQLEditor query={queryWithDefaults} onChange={props.onChange} datasource={props.datasource} />
-          {!props.hideRunQueryButtons && props?.app !== 'explore' && (
-            <div style={{ marginTop: 8 }}>
-              <RunQueryButtons
-                onRunQuery={props.onRunQuery}
-                onCancelQuery={config.featureToggles.athenaAsyncQueryDataSupport ? props.datasource.cancel : undefined}
-                state={props.data?.state}
-                query={props.query}
-                isQueryValid={isQueryValid}
-              />
-            </div>
-          )}
         </div>
       </InlineSegmentGroup>
     </>

--- a/src/VariableQueryEditor.tsx
+++ b/src/VariableQueryEditor.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { AthenaQuery, AthenaDataSourceOptions } from './types';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from 'datasource';
-import { QueryEditor } from 'QueryEditor';
+import { QueryEditorForm } from './QueryEditorForm';
 
 export function VariableQueryCodeEditor(props: QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions>) {
-  return <QueryEditor {...props} hideOptions hideRunQueryButtons />;
+  return <QueryEditorForm {...props} hideOptions />;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,10 +1869,20 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.42.tgz#adfb429df990374e33b1894e39f04692c0bcb71b"
-  integrity sha512-u7UyK1wA84t8L+kKjl+xKndKhTe0KGZYEj8EsQs+AK1JD1E90l4h82zEQGZmcNS5o8LdQeItvRBYPWylbcTp4A==
+"@grafana/async-query-data@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.4.tgz#ac24e32822a8032dd1ee10ce7dcb8c2e276c58b0"
+  integrity sha512-3d7fm2sf5x/+JKTt4T6MSS/veB2J/YGfQp5Ck0Tbqtc5YIoI0p1JY+vFWfCstEHyVd1H0Ep/q/VSxf4VAs9YKQ==
+  dependencies:
+    tslib "^2.4.1"
+
+"@grafana/aws-sdk@0.0.44":
+  version "0.0.44"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.44.tgz#e4a351e6c04d6aa4403e57fbf7eb33946a91a647"
+  integrity sha512-L5wdKL1/eelD9urqHFzpal1fOWSx0FNOOSC5NT+t59bs3VUWrYRllccQ8EiGmAULTTMIuudSbzocaLacp6ET4A==
+  dependencies:
+    "@grafana/async-query-data" "0.1.4"
+    "@grafana/experimental" "1.1.0"
 
 "@grafana/data@9.3.2":
   version "9.3.2"
@@ -1954,6 +1964,14 @@
     eslint-plugin-react-hooks "4.3.0"
     prettier "2.5.1"
     typescript "4.4.4"
+
+"@grafana/experimental@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.1.0.tgz#36b9644b1e61c782ed42b4805c5e297f2cc3f8bf"
+  integrity sha512-pQhYhw+jB7Q+t8rLcd1jcx91BiFDNslBATJkNIgO9I2Bah+ww+2RH1hUGVoJNPL84vW7WRU7w9k/L7FJs7/L6Q==
+  dependencies:
+    "@types/uuid" "^8.3.3"
+    uuid "^8.3.2"
 
 "@grafana/experimental@^0.0.2-canary.39":
   version "0.0.2-canary.39"


### PR DESCRIPTION
Implements [Add a Query Editor Header to AWS datasources#37](https://github.com/grafana/grafana-aws-sdk-react/issues/37)

<img width="650" alt="Screen Shot 2023-02-23 at 2 24 37 PM" src="https://user-images.githubusercontent.com/16140639/220919503-884c93ac-3d84-45fa-a7ce-25e266fc8199.png">


I realize the diff looks a bit confusing, it's due to the new component QueryEditor and the old one (now renamed to QueryEditorForm) being detected as the same file by git. Which means all the history for the form component is lost and I'm not super happy about that, but not sure what can be done, apart from renaming the component something different. 
I tried to do separate commits, one with renaming and the other with the new file created, but that didn't help. LMK if this is an issue and I can think of a new name for QueryEditor.tsx