### PR TITLE
update package.json per contributing guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
+    "dev": "webpack -c ./.config/webpack/webpack.config.ts --env development",
     "e2e": "yarn cypress install && yarn grafana-e2e run",
     "e2e:open": "grafana-e2e open",
     "e2e:update": "yarn cypress install && yarn grafana-e2e run --update-screenshots",
@@ -17,7 +17,8 @@
     "test:ci": "jest --maxWorkers 4",
     "test:coverage": "jest --coverage",
     "test:coverage:changes": "jest --coverage --changedSince=origin/main",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "watch": "webpack -w -c ./.config/webpack/webpack.config.ts --env development"
   },
   "author": "Grafana Labs",
   "license": "Apache-2.0",


### PR DESCRIPTION
- `yarn watch` did not exist, this pr adds this script to run the plugin in watch mode
- `yarn dev` ran the plugin in watch mode, but now builds the plugin in development mode

I think this is more in sync with the instruction in [the contributing guide](https://github.com/grafana/athena-datasource/blob/main/CONTRIBUTING.md)