### PR TITLE
Update dependencies and prepare release 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+ 
+## 2.7.0
+
+* Add header to Query Editor by @idastambuk in [#217](https://github.com/grafana/athena-datasource/pull/211)
+* Add Query Result Reuse Support to Backend by @kevinwcyu[#214](https://github.com/grafana/athena-datasource/pull/214)
 
 ## 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.7.0
 
 * Add header to Query Editor by @idastambuk in [#217](https://github.com/grafana/athena-datasource/pull/211)
-* Add Query Result Reuse Support to Backend by @kevinwcyu[#214](https://github.com/grafana/athena-datasource/pull/214)
+* Add Query Result Reuse Support to Backend by @kevinwcyu in [#214](https://github.com/grafana/athena-datasource/pull/214)
 
 ## 2.6.0
 

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,10 @@ require (
 	github.com/aws/aws-sdk-go v1.44.189
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.8
-	github.com/grafana/grafana-aws-sdk v0.13.0
+	github.com/grafana/grafana-aws-sdk v0.14.0
 	github.com/grafana/grafana-plugin-sdk-go v0.139.0
 	github.com/grafana/sqlds/v2 v2.3.10
+	github.com/magefile/mage v1.14.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.2
 	github.com/uber/athenadriver v1.1.14-0.20210910155546-e1e4a4cd6895

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-aws-sdk v0.13.0 h1:v6oGsdbGXMLD6f4soPOCWd7ya2n5TE1Vtbl1/mhP90E=
-github.com/grafana/grafana-aws-sdk v0.13.0/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
+github.com/grafana/grafana-aws-sdk v0.14.0 h1:JkpAlaHDPkd6Eu5OAsxo0/bZxqmzt9pfJ5LECkWq1TA=
+github.com/grafana/grafana-aws-sdk v0.14.0/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.134.0/go.mod h1:jmrxelOJKrIK0yrsIzcotS8pbqPZozbmJgGy7k3hK1k=
 github.com/grafana/grafana-plugin-sdk-go v0.139.0 h1:2RQKM2QpSaWTtaGN6sK+R7LO7zykOeTYF0QkAMA7JsI=
@@ -344,8 +344,9 @@ github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0U
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magefile/mage v1.11.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magefile/mage v1.12.1/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/magefile/mage v1.13.0 h1:XtLJl8bcCM7EFoO8FyH8XK3t7G5hQAeK+i4tq+veT9M=
 github.com/magefile/mage v1.13.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
- Update grafana-aws-sdk dependency to contain [the most recent fix for async queries](https://github.com/grafana/grafana-aws-sdk/pull/73)
- Prepare release 2.7.0