### PR TITLE
Use default region in GetAsyncDB

### DIFF
--- a/pkg/athena/datasource.go
+++ b/pkg/athena/datasource.go
@@ -85,6 +85,11 @@ func (s *AthenaDatasource) GetAsyncDB(config backend.DataSourceInstanceSettings,
 		return nil, err
 	}
 
+	// athena datasources require a region to establish a connection, we use a default region if none was provided
+	if args["region"] == "" {
+		args["region"] = sqlModels.DefaultKey
+	}
+
 	return s.awsDS.GetAsyncDB(config.ID, args, models.New, api.New, driver.New)
 }
 

--- a/pkg/athena/datasource_test.go
+++ b/pkg/athena/datasource_test.go
@@ -52,6 +52,22 @@ func TestConnection(t *testing.T) {
 		assert.Equal(t, "__default", mc.wasCalledWith["region"])
 	})
 
+	t.Run("it should call getAsyncDB with the default region if none is set", func(t *testing.T) {
+		mc := mockClient{}
+		ds := AthenaDatasource{
+			awsDS: &mc,
+		}
+
+		fakeConfig := backend.DataSourceInstanceSettings{
+			JSONData: json.RawMessage{},
+		}
+		fakeQueryArgs := json.RawMessage(`{"test": "thing", "region": ""}`)
+		_, err := ds.GetAsyncDB(fakeConfig, fakeQueryArgs)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "__default", mc.wasCalledWith["region"])
+	})
+
 	t.Run("it should call getAsyncDB with the resultReuseEnabled option if one is provided", func(t *testing.T) {
 		mc := mockClient{}
 		ds := AthenaDatasource{


### PR DESCRIPTION
Connect for the synchronous queries checks and sets a default version(https://github.com/grafana/athena-datasource/pull/168) so GetAsyncDB should also. Technically I haven't found it causing a bug, but I can't see it not being an issue if its an issue for the sync version