### PR TITLE
Update readme re:G10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.4
+
+- Upgrade Readme.md re: Grafana 10 https://github.com/grafana/athena-datasource/pull/237
+
 ## 2.9.3
 
 - Upgrade grafana/aws-sdk-react to 0.0.46 https://github.com/grafana/athena-datasource/pull/235

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Grafana 10 breaking change: update Athena datasource plugin to >=2.9.3
+
+Grafana 10.0.0 was shipped with the new React 18 upgrade. Changes in batching of state updates in React 18 cause a bug in the query editor in Athena versions <=2.9.2. If you’re using Grafana@>=10.0.0, please update your plugin to version 2.9.3 or higher in your Grafana instance management console.
+
 # Athena data source for Grafana
 
 The Athena data source plugin allows you to query and visualize Athena data metrics from within Grafana.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
This should make sure we have more visibility on the bugfix, since the Readme.md is displayed in the plugin details page: https://grafana.com/grafana/plugins/grafana-athena-datasource/  (that the customer can get to from their "installed plugins" overview)

I put it at the top, but lmk if I should move it
