### PR TITLE
Draft: Add default query methods for query, annotations and variable editor

### DIFF
--- a/src/QueryEditorForm.tsx
+++ b/src/QueryEditorForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './datasource';
-import { AthenaDataSourceOptions, AthenaQuery, defaultQuery, SelectableFormatOptions } from './types';
+import { AthenaDataSourceOptions, AthenaQuery, SelectableFormatOptions } from './types';
 import { InlineSegmentGroup } from '@grafana/ui';
 import { FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
 import { selectors } from 'tests/selectors';
@@ -16,6 +16,7 @@ type Props = QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions> 
 type QueryProperties = 'regions' | 'catalogs' | 'databases' | 'tables' | 'columns';
 
 export function QueryEditorForm(props: Props) {
+  const { query } = props;
   const [resultReuseSupported, setResultReuseSupported] = useState(false);
   useEffect(() => {
     const getIsResultReuseSupported = async () => {
@@ -23,36 +24,22 @@ export function QueryEditorForm(props: Props) {
     };
     getIsResultReuseSupported();
   }, [props.datasource]);
-  const queryWithDefaults = {
-    ...defaultQuery,
-    ...props.query,
-    connectionArgs: {
-      ...defaultQuery.connectionArgs,
-      ...props.query.connectionArgs,
-    },
-  };
 
   const templateVariables = props.datasource.getVariables();
 
   const fetchRegions = () =>
     props.datasource.getRegions().then((regions) => appendTemplateVariables(templateVariables, regions));
   const fetchCatalogs = () =>
-    props.datasource
-      .getCatalogs(queryWithDefaults)
-      .then((catalogs) => appendTemplateVariables(templateVariables, catalogs));
+    props.datasource.getCatalogs(query).then((catalogs) => appendTemplateVariables(templateVariables, catalogs));
   const fetchDatabases = () =>
-    props.datasource
-      .getDatabases(queryWithDefaults)
-      .then((databases) => appendTemplateVariables(templateVariables, databases));
+    props.datasource.getDatabases(query).then((databases) => appendTemplateVariables(templateVariables, databases));
   const fetchTables = () =>
-    props.datasource.getTables(queryWithDefaults).then((tables) => appendTemplateVariables(templateVariables, tables));
+    props.datasource.getTables(query).then((tables) => appendTemplateVariables(templateVariables, tables));
   const fetchColumns = () =>
-    props.datasource
-      .getColumns(queryWithDefaults)
-      .then((columns) => appendTemplateVariables(templateVariables, columns));
+    props.datasource.getColumns(query).then((columns) => appendTemplateVariables(templateVariables, columns));
 
   const onChange = (prop: QueryProperties) => (e: SelectableValue<string> | null) => {
-    const newQuery = { ...props.query };
+    const newQuery = { ...query };
     const value = e?.value;
     switch (prop) {
       case 'regions':
@@ -81,7 +68,7 @@ export function QueryEditorForm(props: Props) {
           <ResourceSelector
             onChange={onChange('regions')}
             fetch={fetchRegions}
-            value={queryWithDefaults.connectionArgs.region ?? null}
+            value={query.connectionArgs.region ?? null}
             default={props.datasource.defaultRegion}
             label={selectors.components.ConfigEditor.region.input}
             data-testid={selectors.components.ConfigEditor.region.wrapper}
@@ -91,9 +78,9 @@ export function QueryEditorForm(props: Props) {
           <ResourceSelector
             onChange={onChange('catalogs')}
             fetch={fetchCatalogs}
-            value={queryWithDefaults.connectionArgs.catalog ?? null}
+            value={query.connectionArgs.catalog ?? null}
             default={props.datasource.defaultCatalog}
-            dependencies={[queryWithDefaults.connectionArgs.region]}
+            dependencies={[query.connectionArgs.region]}
             label={selectors.components.ConfigEditor.catalog.input}
             data-testid={selectors.components.ConfigEditor.catalog.wrapper}
             labelWidth={11}
@@ -102,9 +89,9 @@ export function QueryEditorForm(props: Props) {
           <ResourceSelector
             onChange={onChange('databases')}
             fetch={fetchDatabases}
-            value={queryWithDefaults.connectionArgs.database ?? null}
+            value={query.connectionArgs.database ?? null}
             default={props.datasource.defaultDatabase}
-            dependencies={[queryWithDefaults.connectionArgs.catalog]}
+            dependencies={[query.connectionArgs.catalog]}
             label={selectors.components.ConfigEditor.database.input}
             data-testid={selectors.components.ConfigEditor.database.wrapper}
             labelWidth={11}
@@ -113,8 +100,8 @@ export function QueryEditorForm(props: Props) {
           <ResourceSelector
             onChange={onChange('tables')}
             fetch={fetchTables}
-            value={props.query.table || null}
-            dependencies={[queryWithDefaults.connectionArgs.database]}
+            value={query.table || null}
+            dependencies={[query.connectionArgs.database]}
             tooltip="Use the selected table with the $__table macro"
             label={selectors.components.ConfigEditor.table.input}
             data-testid={selectors.components.ConfigEditor.table.wrapper}
@@ -124,25 +111,25 @@ export function QueryEditorForm(props: Props) {
           <ResourceSelector
             onChange={onChange('columns')}
             fetch={fetchColumns}
-            value={props.query.column || null}
-            dependencies={[queryWithDefaults.table]}
+            value={query.column || null}
+            dependencies={[query.table]}
             tooltip="Use the selected column with the $__column macro"
             label={selectors.components.ConfigEditor.column.input}
             data-testid={selectors.components.ConfigEditor.column.wrapper}
             labelWidth={11}
             className="width-12"
           />
-          <ResultReuse enabled={resultReuseSupported} query={props.query} onChange={props.onChange} />
+          <ResultReuse enabled={resultReuseSupported} query={query} onChange={props.onChange} />
           {!props.hideOptions && (
             <>
               <h6>Frames</h6>
-              <FormatSelect query={props.query} options={SelectableFormatOptions} onChange={props.onChange} />
+              <FormatSelect query={query} options={SelectableFormatOptions} onChange={props.onChange} />
             </>
           )}
         </div>
 
         <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
-          <SQLEditor query={queryWithDefaults} onChange={props.onChange} datasource={props.datasource} />
+          <SQLEditor query={query} onChange={props.onChange} datasource={props.datasource} />
         </div>
       </InlineSegmentGroup>
     </>

--- a/src/annotationSupport.ts
+++ b/src/annotationSupport.ts
@@ -1,5 +1,9 @@
+import { defaultQuery } from 'types';
 import { AnnotationQueryEditor } from './AnnotationQueryEditor';
 
 export const annotationSupport = {
   QueryEditor: AnnotationQueryEditor,
+  getDefaultQuery() {
+    return defaultQuery;
+  },
 };

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,6 +1,6 @@
-import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
+import { CoreApp, DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
 import { config, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
-import { AthenaDataSourceOptions, AthenaQuery } from './types';
+import { AthenaDataSourceOptions, AthenaQuery, defaultQuery } from './types';
 import { AthenaVariableSupport } from './variables';
 import { filterSQLQuery, applySQLTemplateVariables } from '@grafana/aws-sdk';
 import { DatasourceWithAsyncBackend } from '@grafana/async-query-data';
@@ -108,5 +108,9 @@ export class DataSource extends DatasourceWithAsyncBackend<AthenaQuery, AthenaDa
     options.targets = this.buildQuery(options, queries);
 
     return super.query(options);
+  }
+
+  getDefaultQuery(_: CoreApp): Partial<AthenaQuery> {
+    return defaultQuery;
   }
 }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -15,8 +15,11 @@ export class AthenaVariableSupport extends CustomVariableSupport<DataSource, Ath
   editor = VariableQueryCodeEditor;
 
   query(request: DataQueryRequest<AthenaQuery>): Observable<DataQueryResponse> {
-    // fill query params with default data
-    assign(request.targets, [{ ...defaultQuery, ...request.targets[0], refId: 'A' }]);
+    assign(request.targets, [{ ...request.targets[0], refId: 'A' }]);
     return this.datasource.query(request);
+  }
+
+  getDefaultQuery() {
+    return defaultQuery;
   }
 }


### PR DESCRIPTION
The defaultQuery will be applied at set up of the query editor in the panel, as well as at setup of annotations and variable editors. This is why it has to be defined in all 3 places, datasource.ts, variables.ts and annotations.ts. This way the default query won't have to be applied on every rerender of the QueryEditor. 


(PRs for adding support for [variables](https://github.com/grafana/grafana/pull/62026) and [annotations](https://github.com/grafana/grafana/pull/61870) in grafana/grafana for context)

Fixes https://github.com/grafana/athena-datasource/issues/186