### PR TITLE
Include partitions as columns

### DIFF
--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -307,6 +307,9 @@ func (c *API) Columns(ctx aws.Context, options sqlds.Options) ([]string, error) 
 	for _, cat := range out.TableMetadata.Columns {
 		res = append(res, *cat.Name)
 	}
+	for _, par := range out.TableMetadata.PartitionKeys {
+		res = append(res, *par.Name)
+	}
 	return res, nil
 }
 


### PR DESCRIPTION
### Issue Description
The Columns endpoint was not accounting for partition columns. As a result, grafana UI was not able to populate the column drop down with partitions.

**Athena Query UI showing partition columns:**
<img width="339" alt="Screenshot 2023-05-26 at 5 52 19 PM" src="https://github.com/grafana/athena-datasource/assets/29632756/7a689699-8731-40ec-a09d-ab200cc493f2">

**Grafana column dropdown omitting partition columns:**
<img width="488" alt="Screenshot 2023-05-26 at 5 52 37 PM" src="https://github.com/grafana/athena-datasource/assets/29632756/4dc81970-451b-47eb-a9ec-8454681dc2ee">
