### PR TITLE
Add instructions to contributing guide for setting up a go workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Make sure you have the following dependencies installed first:
 
 ## Setting up a go workspace
 
-Setting up go workspace can be helpful when making across modules like `grafana-aws-sdk` and `sqlds` and wanting to see those changes in the Athena data source.
+Setting up go workspace can be helpful when making changes across modules like `grafana-aws-sdk` and `sqlds` and wanting to see those changes reflected in the Athena data source.
 
 From https://go.dev/blog/get-familiar-with-workspaces:
 > Workspaces in Go 1.18 let you work on multiple modules simultaneously without having to edit go.mod files for each module. Each module within a workspace is treated as a main module when resolving dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,8 @@ From https://go.dev/blog/get-familiar-with-workspaces:
 5. `git clone https://github.com/grafana/sqlds`
 6. `go work init ./athena-datasource ./grafana-aws-sdk ./sqlds`
 7. Make modifications in any of these directories and build the backend in `athena-datasource` with `mage` as usual. The changes in these directories will be taken into account.
-8. Symlink `athena-datasource` to your clone of `github.com/grafana/grafana`'s `data/plugins` directory, e.g. `cd <path to your Grafana repo>/github.com/grafana/grafana/data/plugins && ln -s <path to your workspaces>/athena_workspace/athena-datasource athena-datasource`
+
+If you build Grafana locally, you can for example symlink `athena-datasource` to your clone of `github.com/grafana/grafana`'s `data/plugins` directory, e.g. `cd <path to your Grafana repo>/github.com/grafana/grafana/data/plugins && ln -s <path to your workspaces>/athena_workspace/athena-datasource athena-datasource`
 
 ## Build a release for the Athena data source plugin
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,24 @@ Make sure you have the following dependencies installed first:
    mage -v
    ```
 
+## Setting up a go workspace
+
+Setting up go workspace can be helpful when making across modules like `grafana-aws-sdk` and `sqlds` and wanting to see those changes in the Athena data source.
+
+From https://go.dev/blog/get-familiar-with-workspaces:
+> Workspaces in Go 1.18 let you work on multiple modules simultaneously without having to edit go.mod files for each module. Each module within a workspace is treated as a main module when resolving dependencies.
+> 
+> Previously, to add a feature to one module and use it in another module, you needed to either publish the changes to the first module, or edit the go.mod file of the dependent module with a replace directive for your local, unpublished module changes. In order to publish without errors, you had to remove the replace directive from the dependent module’s go.mod file after you published the local changes to the first module.
+
+1. Make a new directory somewhere, for example `athena_workspace`
+2. `cd athena_workspace`
+3. `git clone https://github.com/grafana/athena-datasource.git`
+4. `git clone https://github.com/grafana/grafana-aws-sdk`
+5. `git clone https://github.com/grafana/sqlds`
+6. `go work init ./athena-datasource ./grafana-aws-sdk ./sqlds`
+7. Make modifications in any of these directories and build the backend in `athena-datasource` with `mage` as usual. The changes in these directories will be taken into account.
+8. Symlink `athena-datasource` to your clone of `github.com/grafana/grafana`'s `data/plugins` directory, e.g. `cd <path to your Grafana repo>/github.com/grafana/grafana/data/plugins && ln -s <path to your workspaces>/athena_workspace/athena-datasource athena-datasource`
+
 ## Build a release for the Athena data source plugin
 
 ### Pre-requisites


### PR DESCRIPTION
This explains how to set up a go workspace which helps when working across some of the backend dependencies without having to modify `go.mod` with `replace`. 

This is for any contributors who build this data source locally. 

Contributes to https://github.com/grafana/oss-plugin-partnerships/issues/146