### PR TITLE
Since this golang module is v2 the go.mod needs to reflect that.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafana/athena-datasource
+module github.com/grafana/athena-datasource/v2
 
 go 1.20
 


### PR DESCRIPTION
The go.mod file needs to have the right version, and since this grafana data source is v2.10.0, the module needs to be `/v2`.

invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2