### PR TITLE
Support async query caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ Async query data support enables an asynchronous query handling flow. With async
 
 To enable async query data support, you need to set feature toggle `athenaAsyncQueryDataSupport` to `true`. See [Configure feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles) for details.
 
+### Async Query Caching
+
+To enable [query caching](https://grafana.com/docs/grafana/latest/administration/data-source-management/#query-caching) for async queries, you need to be on Grafana version 10.1 or above, and to set the feature toggles `useCachingService` and `awsAsyncQueryCaching` to `true`. You'll also need to [configure query caching](https://grafana.com/docs/grafana/latest/administration/data-source-management/#query-caching) for the specific Athena datasource.
+
 ## Query Result Reuse
 
 Query result reuse is a feature that allows Athena to reuse query results from previous queries. You can enable it per query by selecting the `Enabled` checkbox under the `Query result reuse` section in the query editor. Learn more in the [AWS Athena documentation](https://docs.aws.amazon.com/athena/latest/ug/reusing-query-results.html).

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/aws/aws-sdk-go v1.44.194
 	github.com/google/go-cmp v0.5.9
-	github.com/grafana/grafana-aws-sdk v0.15.1
+	github.com/grafana/grafana-aws-sdk v0.16.1
 	github.com/grafana/grafana-plugin-sdk-go v0.161.0
 	github.com/grafana/sqlds/v2 v2.3.10
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grafana/athenadriver v0.0.0-20230518203225-a81b0073ac84 h1:RorAX08zpt0qpfsV2fOIs0XKvPT1y0I4h6hleFZ13pA=
 github.com/grafana/athenadriver v0.0.0-20230518203225-a81b0073ac84/go.mod h1:RnKD7+9Aup8iuFfhK+I26U+z137IXWeoLaEZDepd0Eg=
-github.com/grafana/grafana-aws-sdk v0.15.1 h1:OVGTCSpR40BXol+KgLkWZJzc5sNgKmZheYB6j+aE14E=
-github.com/grafana/grafana-aws-sdk v0.15.1/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
+github.com/grafana/grafana-aws-sdk v0.16.1 h1:R/hMtQP7H0+8nWFoIOApaZj0qstmZM+5Pw0rRzk3A3Y=
+github.com/grafana/grafana-aws-sdk v0.16.1/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.161.0 h1:UjVjRGQ5cuT4Ok30qUeLW2OhQhx9Whuz9Oz/1KsBvVM=
 github.com/grafana/grafana-plugin-sdk-go v0.161.0/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@grafana/async-query-data": "0.1.6",
+    "@grafana/async-query-data": "0.1.9",
     "@grafana/experimental": "^0.0.2-canary.39"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1541,10 +1541,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/async-query-data@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.6.tgz#2de218afba9a08bdece3d906c67fa51d331fb8e2"
-  integrity sha512-KH6JQiM0JPqP6STk4TCRF36DbNrZxwelDLrDr9tvqYXJ6K7T+Q/7+INtsP9XBZjf4I8No1OeJxYeT5iUUYFxag==
+"@grafana/async-query-data@0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.9.tgz#f366247a26f5353dc48ab24e1521fa1bed00f528"
+  integrity sha512-qjWNAM2nhTdrdCLBwfhX4jt783k2lqfzptAz1wqQj6E0mJgzGkSKdomdDwU8ZLtokeld/FT5jqzVXTXb3nKScg==
   dependencies:
     tslib "^2.4.1"
 


### PR DESCRIPTION
Updates the dependencies to the versions that support async query caching.

Note that to enable it you need to use enterprise Grafana version 10.1.x, with caching turned on for the Athena datasource and `useCachingService = true` and `awsAsyncQueryCaching = true` in the custom.ini.