### PR TITLE
Remove unused "Updated" field from structs

### DIFF
--- a/pkg/athena/datasource.go
+++ b/pkg/athena/datasource.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/grafana/athena-datasource/pkg/athena/api"
 	"github.com/grafana/athena-datasource/pkg/athena/driver"
@@ -26,7 +25,6 @@ type athenaQueryArgs struct {
 	Region, Catalog, Database  string
 	ResultReuseEnabled         bool
 	ResultReuseMaxAgeInMinutes int64
-	Updated                    *time.Time
 }
 
 type awsDSClient interface {

--- a/pkg/athena/models/settings.go
+++ b/pkg/athena/models/settings.go
@@ -17,7 +17,6 @@ const (
 	Catalog                    = "catalog"
 	ResultReuseEnabled         = "resultReuseEnabled"
 	ResultReuseMaxAgeInMinutes = "resultReuseMaxAgeInMinutes"
-	Updated                    = "updated"
 )
 
 type AthenaDataSourceSettings struct {


### PR DESCRIPTION
I added `Updated` fields to some of the parsing structs in https://github.com/grafana/athena-datasource/pull/262 , but they didn't end up being used. They were accidentally pushed to the pr instead of getting cleaned up