### PR TITLE
Update grafana/aws-sdk dependency and release 2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 2.10.2
 
-- Upgrade @grafana/aws-sdk to v0.0.48 to use @grafana/runtime instead of grafanaBootData 
+- Upgrade @grafana/aws-sdk to v0.0.48 to use @grafana/runtime instead of grafanaBootData [#267](https://github.com/grafana/athena-datasource/pull/267)
+- Remove unused updated field from structs [#263](https://github.com/grafana/athena-datasource/pull/263)
+- Fix connection error when changing access and secret key [#262](https://github.com/grafana/athena-datasource/pull/262)
 
 ## 2.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.10.2
+
+- Upgrade @grafana/aws-sdk to v0.0.48 to use @grafana/runtime instead of grafanaBootData 
+
 ## 2.10.1
 
 - Update dependencies and rebuild lockfile

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -60,6 +60,7 @@
     "varbinary",
     "varchar",
     "viant",
-    "Workgroups"
+    "Workgroups",
+    "structs"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.0.47",
+    "@grafana/aws-sdk": "0.0.48",
     "@grafana/data": "9.3.2",
     "@grafana/e2e": "9.3.2",
     "@grafana/e2e-selectors": "9.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,10 +1548,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.0.47":
-  version "0.0.47"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.47.tgz#2150acd3a39c7c1639eac827c553a8bc440d514a"
-  integrity sha512-7SvIJFg0E9IhO+OogQH9p/Nte81XDGqiy1ru8rv7XoFFt1NFGTGxNUCsamOMX32mMNo2m91jHaifj5ZrMYeT/g==
+"@grafana/aws-sdk@0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.48.tgz#8831b7dc21d4b338b324a22bcaaccde116cd28bb"
+  integrity sha512-lh6aWRoHw0wlkFKY2Qhb3du6iElA2oOtwsMuTmr3urZPTfMhJEzCPkiA/pWYzZHmKaIeez/EYECirQ16k7pW/w==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
     "@grafana/experimental" "1.1.0"


### PR DESCRIPTION
While testing sandboxing, @kevinwcyu got errors related to use of grafanaBootData in Athena's version of aws-sdk. The package has previously been updated to use config instead of grafanaBootData, so this is just to update the dependency to contain the new code.