### PR TITLE
Add Support for Temporary Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.12.0
+
+- Add support for Temporary Credentials [#284] https://github.com/grafana/athena-datasource/pull/284
+
 ## 2.11.1
 
 - Update @grafana/aws-sdk to 0.1.2 to fix bug with temporary credentials

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@swc/jest": "^0.2.20",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
+    "@testing-library/user-event": "^14.5.1",
     "@types/glob": "^8.0.0",
     "@types/jest": "^27.4.1",
     "@types/lodash": "latest",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.1.2",
+    "@grafana/aws-sdk": "0.2.0",
     "@grafana/data": "9.3.2",
     "@grafana/e2e": "9.3.2",
     "@grafana/e2e-selectors": "9.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/athena/routes/routes.go
+++ b/pkg/athena/routes/routes.go
@@ -2,8 +2,10 @@ package routes
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/grafana/athena-datasource/pkg/athena"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-aws-sdk/pkg/sql/routes"
 )
 
@@ -49,10 +51,22 @@ func (r *(AthenaResourceHandler)) workgroupEngineVersion(rw http.ResponseWriter,
 	routes.SendResources(rw, res, err)
 }
 
+type ExternalIdResponse struct {
+	ExternalId string `json:"externalId"`
+}
+
+func (r *AthenaResourceHandler) externalId(rw http.ResponseWriter, req *http.Request) {
+	res := ExternalIdResponse{
+		ExternalId: os.Getenv(awsds.GrafanaAssumeRoleExternalIdKeyName),
+	}
+	routes.SendResources(rw, res, nil)
+}
+
 func (r *AthenaResourceHandler) Routes() map[string]func(http.ResponseWriter, *http.Request) {
 	routes := r.DefaultRoutes()
 	routes["/catalogs"] = r.catalogs
 	routes["/workgroups"] = r.workgroups
 	routes["/workgroupEngineVersion"] = r.workgroupEngineVersion
+	routes["/externalId"] = r.externalId
 	return routes
 }

--- a/pkg/athena/routes/routes_test.go
+++ b/pkg/athena/routes/routes_test.go
@@ -129,10 +129,11 @@ func TestRoutes(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 		},
 		{
-			description:  "externalId",
-			route:        "/externalId",
-			reqBody:      []byte{},
-			expectedCode: http.StatusOK,
+			description:    "externalId",
+			route:          "/externalId",
+			reqBody:        []byte{},
+			expectedCode:   http.StatusOK,
+			expectedResult: `{"externalId":""}`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/athena/routes/routes_test.go
+++ b/pkg/athena/routes/routes_test.go
@@ -184,7 +184,7 @@ func TestRoutes_ExternalId(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Equal(t, `{"externalId":"a fake external id"}`, string(body))
 	})
-	t.Run("it returns an empty string if there is no externalid set in the env", func(t *testing.T) {
+	t.Run("it returns an empty string if there is no external id set in the env", func(t *testing.T) {
 		rh := setupHandler()
 		resp, body, err := hitRoute(rh, "/externalId", []byte{})
 

--- a/pkg/athena/routes/routes_test.go
+++ b/pkg/athena/routes/routes_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/athena-datasource/pkg/athena/fake"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/stretchr/testify/require"
 )
 
 var ds = &fake.AthenaFakeDatasource{
@@ -126,6 +128,12 @@ func TestRoutes(t *testing.T) {
 			reqBody:      []byte{},
 			expectedCode: http.StatusBadRequest,
 		},
+		{
+			description:  "externalId",
+			route:        "/externalId",
+			reqBody:      []byte{},
+			expectedCode: http.StatusOK,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
@@ -148,4 +156,41 @@ func TestRoutes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setupHandler() AthenaResourceHandler {
+	rh := AthenaResourceHandler{athena: ds}
+	rh.API = ds
+	return rh
+}
+
+func hitRoute(rh AthenaResourceHandler, route string, reqBody []byte) (*http.Response, []byte, error) {
+	req := httptest.NewRequest("GET", route, bytes.NewReader(reqBody))
+	rw := httptest.NewRecorder()
+	rh.Routes()[route](rw, req)
+	resp := rw.Result()
+	body, err := io.ReadAll(resp.Body)
+	return resp, body, err
+}
+func TestRoutes_ExternalId(t *testing.T) {
+
+	t.Run("it returns an externalId if one is set in the env", func(t *testing.T) {
+		t.Setenv(awsds.GrafanaAssumeRoleExternalIdKeyName, "a fake external id")
+
+		rh := setupHandler()
+		resp, body, err := hitRoute(rh, "/externalId", []byte{})
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, `{"externalId":"a fake external id"}`, string(body))
+	})
+	t.Run("it returns an empty string if there is no externalid set in the env", func(t *testing.T) {
+		rh := setupHandler()
+		resp, body, err := hitRoute(rh, "/externalId", []byte{})
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, `{"externalId":""}`, string(body))
+	})
+
 }

--- a/src/ConfigEditor.test.tsx
+++ b/src/ConfigEditor.test.tsx
@@ -101,7 +101,7 @@ describe('ConfigEditor', () => {
     });
   });
 
-  it('should fetch and display externalId when the authtype is grafana_assume_role', async () => {
+  it('should fetch and display externalId when the auth type is grafana_assume_role', async () => {
     setUpMockBackendServer({
       put: jest.fn().mockResolvedValue({ datasource: {} }),
       post: jest.fn().mockResolvedValue({ externalId: 'fake-external-id' }),

--- a/src/ConfigEditor.test.tsx
+++ b/src/ConfigEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ConfigEditor } from './ConfigEditor';
 import { mockDatasourceOptions } from './__mocks__/datasource';
 import { select } from 'react-select-event';

--- a/src/ConfigEditor.test.tsx
+++ b/src/ConfigEditor.test.tsx
@@ -1,40 +1,34 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { ConfigEditor } from './ConfigEditor';
 import { mockDatasourceOptions } from './__mocks__/datasource';
 import { select } from 'react-select-event';
 import { selectors } from 'tests/selectors';
+import { AwsAuthType } from '@grafana/aws-sdk';
+import * as runtime from '@grafana/runtime';
+import userEvent from '@testing-library/user-event';
 
 const resourceName = 'foo';
-
-jest.mock('@grafana/aws-sdk', () => {
-  return {
-    ...(jest.requireActual('@grafana/aws-sdk') as any),
-    ConnectionConfig: function ConnectionConfig() {
-      return <></>;
-    },
-  };
-});
-jest.mock('@grafana/runtime', () => {
-  return {
-    ...(jest.requireActual('@grafana/runtime') as any),
-    getBackendSrv: () => ({
-      put: jest.fn().mockResolvedValue({ datasource: {} }),
-      post: jest.fn().mockResolvedValue([resourceName]),
-    }),
-  };
-});
 const props = mockDatasourceOptions;
+
+const setUpMockBackendServer = (mockBackendSrv: { put: () => void; post: () => void }) => {
+  jest.spyOn(runtime, 'getBackendSrv').mockImplementation(() => mockBackendSrv as unknown as runtime.BackendSrv);
+};
 
 describe('ConfigEditor', () => {
   it('should save and request catalogs', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue([resourceName]),
+    });
+
     const onChange = jest.fn();
     render(<ConfigEditor {...props} onOptionsChange={onChange} />);
 
     const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.catalog.input);
     expect(selectEl).toBeInTheDocument();
 
-    await select(selectEl, resourceName, { container: document.body });
+    await waitFor(() => select(selectEl, resourceName, { container: document.body }));
 
     expect(onChange).toHaveBeenCalledWith({
       ...props.options,
@@ -43,6 +37,11 @@ describe('ConfigEditor', () => {
   });
 
   it('should save and request databases', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue([resourceName]),
+    });
+
     const onChange = jest.fn();
     render(<ConfigEditor {...props} onOptionsChange={onChange} />);
 
@@ -53,7 +52,7 @@ describe('ConfigEditor', () => {
     const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.database.input);
     expect(selectEl).toBeInTheDocument();
 
-    await select(selectEl, resourceName, { container: document.body });
+    await waitFor(() => select(selectEl, resourceName, { container: document.body }));
 
     expect(onChange).toHaveBeenCalledWith({
       ...props.options,
@@ -62,6 +61,11 @@ describe('ConfigEditor', () => {
   });
 
   it('should save and request workgroups', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue([resourceName]),
+    });
+
     const onChange = jest.fn();
     render(<ConfigEditor {...props} onOptionsChange={onChange} />);
 
@@ -72,7 +76,7 @@ describe('ConfigEditor', () => {
     const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.workgroup.input);
     expect(selectEl).toBeInTheDocument();
 
-    await select(selectEl, resourceName, { container: document.body });
+    await waitFor(() => select(selectEl, resourceName, { container: document.body }));
 
     expect(onChange).toHaveBeenCalledWith({
       ...props.options,
@@ -81,6 +85,11 @@ describe('ConfigEditor', () => {
   });
 
   it('should use an output location', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue([resourceName]),
+    });
+
     const onChange = jest.fn();
     render(<ConfigEditor {...props} onOptionsChange={onChange} />);
     const input = screen.getByTestId(selectors.components.ConfigEditor.OutputLocation.wrapper);
@@ -90,5 +99,86 @@ describe('ConfigEditor', () => {
       ...props.options,
       jsonData: { ...props.options.jsonData, outputLocation: bucket },
     });
+  });
+
+  it('should fetch and display externalId when the authtype is grafana_assume_role', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue({ externalId: 'fake-external-id' }),
+    });
+
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          jsonData: {
+            ...props.options.jsonData,
+            authType: AwsAuthType.GrafanaAssumeRole,
+          },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
+    const instructionsButton = await screen.findByRole('button', {
+      name: /How to create an IAM role for grafana to assume/i,
+    });
+    await userEvent.click(instructionsButton);
+    expect(screen.queryByText('fake-external-id')).toBeInTheDocument();
+  });
+
+  it('gracefully handles when the fetch for external id throws an error', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockRejectedValue('the server exploded for some reason'),
+    });
+
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          jsonData: {
+            ...props.options.jsonData,
+            authType: AwsAuthType.GrafanaAssumeRole,
+          },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
+    const instructionsButton = await screen.findByRole('button', {
+      name: /How to create an IAM role for grafana to assume/i,
+    });
+    await userEvent.click(instructionsButton);
+    expect(screen.queryByText('External Id is currently unavailable')).toBeInTheDocument();
+  });
+
+  it('gracefully handles when the fetch for external id return an empty string', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue({ externalId: '' }),
+    });
+
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          jsonData: {
+            ...props.options.jsonData,
+            authType: AwsAuthType.GrafanaAssumeRole,
+          },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
+    const instructionsButton = await screen.findByRole('button', {
+      name: /How to create an IAM role for grafana to assume/i,
+    });
+    await userEvent.click(instructionsButton);
+    expect(screen.queryByText('External Id is currently unavailable')).toBeInTheDocument();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,10 +1548,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.1.2.tgz#5eda0c2814b91610dddc51510f81ae141f44030b"
-  integrity sha512-IZDBFWHPuX8LotJl26RMzHu6gLX6e3SE132EYgDwHSSMQ6fZLFY/t1fy39flG119CLckvsg2oIuKdctrgwVowA==
+"@grafana/aws-sdk@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.2.0.tgz#61baf365680ea868cc1ccbd9d03ee990e1b75968"
+  integrity sha512-MxIKKoeRoCgAWAV9IzSOpQW6DQGTitg/ImNrSv/ugq0hRXDFs879vBbIa92qCxQ3f+FbeBx7Dvl2pVo/tZ5DJw==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
     "@grafana/experimental" "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,6 +2750,11 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
+"@testing-library/user-event@^14.5.1":
+  version "14.5.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.1.tgz#27337d72046d5236b32fd977edee3f74c71d332f"
+  integrity sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
Adds support for our [new Temporary Credentials Feature](https://github.com/grafana/grafana/pull/75178), currently in Private Preview in Grafana Cloud.

Fixes https://github.com/grafana/oss-plugin-partnerships/issues/259

Adds: 
- new resource route: `/externalId` which fetches external id from the env and returns it if there
- hits that new route whenever we load the Config Editor and the selected auth provider is `Grafana Assume Role`

To Test: 
- use a local version of https://github.com/grafana/grafana-aws-sdk-react/pull/63
- Update Custom.ini:
```
[aws]
allowed_auth_providers = keys,grafana_assume_role
assume_role_enabled = true
external_id = '12345678'

[feature_toggles]
awsDatasourcesTempCredentials = true
```

I think it might be easiest to 
- first approve this pr: 
- then merge and publish: https://github.com/grafana/grafana-aws-sdk-react/pull/63
- then update this pr with that updated package version
- then merge and publish this pr.
