### PR TITLE
Query Editor improvements: Update query with defaults on mount and filter out empty queries, prepare 2.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.3
+
+* Query Editor improvements: Update query with defaults on mount and filter out empty queries in [#303](https://github.com/grafana/athena-datasource/pull/30)
+
 ## 2.13.2
 
 * Bump go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc from 0.45.0 to 0.46.0 by @dependabot in https://github.com/grafana/athena-datasource/pull/298

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/QueryEditorForm.test.tsx
+++ b/src/QueryEditorForm.test.tsx
@@ -5,7 +5,7 @@ import { mockDatasource, mockQuery } from './__mocks__/datasource';
 import '@testing-library/jest-dom';
 import { select } from 'react-select-event';
 import { selectors } from 'tests/selectors';
-import { defaultKey } from 'types';
+import { defaultKey, defaultQuery } from 'types';
 import * as runtime from '@grafana/runtime';
 import * as experimental from '@grafana/experimental';
 import { config } from '@grafana/runtime';
@@ -183,6 +183,10 @@ describe('QueryEditor', () => {
         const selectEl = screen.getByLabelText(config.featureToggles.awsDatasourcesNewFormStyling ? 'Format data frames as': 'Format as');
         expect(selectEl).toBeInTheDocument();
       });
+      it('should update query with defaults on mount', () => {
+        render(<QueryEditorForm {...props} />);
+        expect(props.onChange).toHaveBeenCalledWith({...defaultQuery, ...props.query})
+      })
   }
   describe('QueryEditorForm with awsDatasourcesNewFormStyling feature toggle disabled', () => {
     beforeAll(() => {

--- a/src/QueryEditorForm.tsx
+++ b/src/QueryEditorForm.tsx
@@ -212,7 +212,7 @@ export function QueryEditorForm(props: Props) {
           </EditorRow>
           <EditorRow>
             <div style={{ width: '100%' }}>
-              <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
+              <SQLEditor query={queryWithDefaults} onChange={props.onChange} datasource={props.datasource} />
             </div>
           </EditorRow>
         </EditorRows>

--- a/src/QueryEditorForm.tsx
+++ b/src/QueryEditorForm.tsx
@@ -38,6 +38,13 @@ export function QueryEditorForm(props: Props) {
     },
   };
 
+  // Populate the props.query with defaults on mount
+  useEffect(() => {
+    props.onChange(queryWithDefaults);
+    // Run only once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const templateVariables = props.datasource.getVariables();
 
   const fetchRegions = () =>
@@ -212,7 +219,7 @@ export function QueryEditorForm(props: Props) {
           </EditorRow>
           <EditorRow>
             <div style={{ width: '100%' }}>
-              <SQLEditor query={queryWithDefaults} onChange={props.onChange} datasource={props.datasource} />
+              <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
             </div>
           </EditorRow>
         </EditorRows>
@@ -288,7 +295,7 @@ export function QueryEditorForm(props: Props) {
           </div>
 
           <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
-            <SQLEditor query={queryWithDefaults} onChange={props.onChange} datasource={props.datasource} />
+            <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
           </div>
         </InlineSegmentGroup>
       )}

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,6 +1,7 @@
 import { DataQueryRequest, DataSourceInstanceSettings, dateTime } from '@grafana/data';
 import * as runtime from '@grafana/runtime';
 import { AthenaDataSourceOptions, AthenaQuery, FormatOptions } from 'types';
+import { of } from 'rxjs';
 
 import { DataSource } from './datasource';
 
@@ -187,6 +188,15 @@ describe('AthenaDatasource', () => {
       expect(queries).toHaveLength(1);
       expect(queries[0].connectionArgs.region).toEqual('replaced');
     });
+  });
+  it('should not run query if query is empty', async () => {
+    const mockedSuperQuery = jest
+      .spyOn(runtime.DataSourceWithBackend.prototype, 'query')
+      .mockImplementation((request: DataQueryRequest<AthenaQuery>) => of());
+
+    const request = { ...queryRequest, targets: [{ ...defaultQuery, rawSQL: '' }] };
+    ctx.ds.query(request);
+    expect(mockedSuperQuery).toHaveBeenCalledWith({ ...request, targets: [] });
   });
 });
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -103,8 +103,8 @@ export class DataSource extends DatasourceWithAsyncBackend<AthenaQuery, AthenaDa
   query(options: DataQueryRequest<AthenaQuery>): Observable<DataQueryResponse> {
     options = cloneDeep(options);
 
-    const queries = options.targets.filter((item) => item.hide !== true);
-
+    const queries = options.targets.filter((item) => item.hide !== true && item.rawSQL);
+    
     options.targets = this.buildQuery(options, queries);
 
     return super.query(options);


### PR DESCRIPTION
In the old form styling, `query={queryWithDefaults}`[is passed](https://github.com/grafana/athena-datasource/blob/dc0381a6d45fd5d2419a4262212228c39321bb9e/src/QueryEditorForm.tsx#L291) to the QueryEditor. I mistakenly replaced that with `query={props.query}` in the new styling code. This causes an error on Run query in new form styling if the user doesn't select any of the macros manually:

<img width="388" alt="Screenshot 2023-11-26 at 21 21 13" src="https://github.com/grafana/athena-datasource/assets/16140639/40cf7282-14ca-404e-ba99-f656cb942c51"> 

Additionally, because of this, the autocomplete for the macros doesn't work, as we don't have defaults in the query [to request the data.](https://github.com/grafana/athena-datasource/blob/main/src/SQLEditor.tsx#L21) 

The reason for this is that the connectionArgs (region, table etc.) aren't set to the default value. 


Even the current solution in production isn't ideal, as the user has to change the query in the SQL editor for the defaults to get populated. This means if they run the query before editing sql, they will get the same error.

At first, I just replaced the SQL editor props to what we have in the old editor, however because of the bug mentioned above, I decided to refactor this a bit. 
Now we're calling onChange with the default query on mount. I've tested it and it works as expected, but I'd appreciate someone else trying to break it as well. 

P.S.
Ideally, we wouldn't have to set defaults anywhere in the Form, which is why `getDefaultQuery` method was implemented in datasource [here](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/datasource.ts#L372) in core Grafana. However, we decided we wouldn't implement that yet, as it wouldn't work for instances running Grafana<9.3 😔 