### PR TITLE
Bump @grafana/async-query-data from 0.1.10 to 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,28 @@
 # Changelog
 
+## 2.13.5
+
+- Update grafana-aws-sdk from v0.19.3 to v0.23.0 and sqlds from v2.3.10 to v3.2.0 in [#310](https://github.com/grafana/athena-datasource/pull/310)
+- Update @grafana/async-query-data from 0.1.10 to 0.1.11 in [#311](https://github.com/grafana/athena-datasource/pull/311)
+
 ## 2.13.4
 
-* Update README.md: Updates installation, configuration and authentication in [#300](https://github.com/grafana/athena-datasource/pull/300)
-* Bump grafana-aws-sdk from v0.19.1 to v0.19.3 in [#304](https://github.com/grafana/athena-datasource/pull/304)
+- Update README.md: Updates installation, configuration and authentication in [#300](https://github.com/grafana/athena-datasource/pull/300)
+- Bump grafana-aws-sdk from v0.19.1 to v0.19.3 in [#304](https://github.com/grafana/athena-datasource/pull/304)
 
 ## 2.13.3
 
-* Query Editor improvements: Update query with defaults on mount and filter out empty queries in [#303](https://github.com/grafana/athena-datasource/pull/30)
+- Query Editor improvements: Update query with defaults on mount and filter out empty queries in [#303](https://github.com/grafana/athena-datasource/pull/30)
 
 ## 2.13.2
 
-* Bump go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc from 0.45.0 to 0.46.0 by @dependabot in https://github.com/grafana/athena-datasource/pull/298
-* Add debug, underscore to resolutions in package.json by @fridgepoet in https://github.com/grafana/athena-datasource/pull/299
+- Bump go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc from 0.45.0 to 0.46.0 by @dependabot in https://github.com/grafana/athena-datasource/pull/298
+- Add debug, underscore to resolutions in package.json by @fridgepoet in https://github.com/grafana/athena-datasource/pull/299
 
 ## 2.13.1
 
--  Bump google.golang.org/grpc from 1.58.2 to 1.58.3 in [#295] https://github.com/grafana/athena-datasource/pull/295
--  Bump go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace from 0.37.0 to 0.44.0 in [#290] https://github.com/grafana/athena-datasource/pull/290
-
+- Bump google.golang.org/grpc from 1.58.2 to 1.58.3 in [#295] https://github.com/grafana/athena-datasource/pull/295
+- Bump go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace from 0.37.0 to 0.44.0 in [#290] https://github.com/grafana/athena-datasource/pull/290
 
 ## 2.13.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -23,7 +23,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@grafana/async-query-data": "0.1.10",
+    "@grafana/async-query-data": "0.1.11",
     "@grafana/experimental": "1.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,10 +1557,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@grafana/async-query-data@0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.10.tgz#0ecf576b0c72d878bb89aee9d913e2605c485e7d"
-  integrity sha512-3BQFtYjhKqP0WDgHFKHUBGzH6BvTg7aAlSG8rSmQVVYq1N+y+22nPUMZ5LbN/tLrHFVxcOCBGQSEwgN5DnK/YA==
+"@grafana/async-query-data@0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.11.tgz#9964e3ffb25328151d00b67b25a04a5c5c133dd6"
+  integrity sha512-RW2sthimO+0xZl1K6dLWs9F4idvOQ+m/GRgnhuo7LWNYUYkrxlLsFZ6Yz9aRFq1Rkf5HsV0/ldFWlQNmxuL9tQ==
   dependencies:
     tslib "^2.4.1"
 


### PR DESCRIPTION
Updates to a version of async-query-data that sets unique prefixes for requestIds.

You can test this by creating a timestream and a athena panel in the same dashboard or creating panels from 2 distinct athena datasources.

Fixes #259 and Fixes https://github.com/grafana/timestream-datasource/issues/273