### PR TITLE
Rebuild the datasource when settings change

### DIFF
--- a/pkg/athena/routes/routes.go
+++ b/pkg/athena/routes/routes.go
@@ -40,7 +40,7 @@ func (r *AthenaResourceHandler) workgroups(rw http.ResponseWriter, req *http.Req
 	routes.SendResources(rw, res, err)
 }
 
-func (r *(AthenaResourceHandler)) workgroupEngineVersion(rw http.ResponseWriter, req *http.Request) {
+func (r *AthenaResourceHandler) workgroupEngineVersion(rw http.ResponseWriter, req *http.Request) {
 	reqBody, err := routes.ParseBody(req.Body)
 	if err != nil {
 		rw.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
Previously when saving settings the datasource would be partially rebuild but maintain its connection cache, so if auth-related settings changed the change would not be applied. Now the datasource will be rebuilt entirely.

Fixes #264.