### PR TITLE
Prepare 2.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.13.6
+- Fix: Rebuild the datasource when settings change in [#314](https://github.com/grafana/athena-datasource/pull/314)
+- Bring in [security fixes in go 1.21.8](https://groups.google.com/g/golang-announce/c/5pwGVUPoMbg)
+- Remove outdated release instructions from CONTRIBUTING.md
+
 ## 2.13.5
 
 - Update grafana-aws-sdk from v0.19.3 to v0.23.0 and sqlds from v2.3.10 to v3.2.0 in [#310](https://github.com/grafana/athena-datasource/pull/310)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,18 +67,6 @@ If you build Grafana locally, you can for example symlink `athena-datasource` to
 
 ## Build a release for the Athena data source plugin
 
-### Pre-requisites
-
-Before doing a release, make sure that the GitHub repository is configured with a `GRAFANA_API_KEY` to be able to sign the plugin and that the Golang and Node versions in the [release.yaml](./.github/workflows/release.yaml) workflow are correct.
-
-Also, make sure that the path to the plugin validator in the [release.yaml](./.github/workflows/release.yaml#L122) is correct (this fixes the error `pushd: ./plugin-validator/cmd/plugincheck: No such file or directory`):
-
-```
-pushd ./plugin-validator/pkg/cmd/plugincheck`
-```
-
-### Release
-
 You need to have commit rights to the GitHub repository to publish a release.
 
 1. Update the version number in the `package.json` file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
- Fix: Rebuild the datasource when settings change in [#314](https://github.com/grafana/athena-datasource/pull/314)
- Bring in [security fixes in go 1.21.8](https://groups.google.com/g/golang-announce/c/5pwGVUPoMbg)