### PR TITLE
docs: fix 'Using accessKey and secretKey' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ datasources:
     type: grafana-athena-datasource
     jsonData:
       authType: keys
-      defaultRegion: euu-west-2
+      defaultRegion: eu-west-2
       catalog: AwsDataCatalog
       database: '<your athena database>'
       workgroup: '<your athena workgroup>'

--- a/README.md
+++ b/README.md
@@ -241,13 +241,13 @@ datasources:
     type: grafana-athena-datasource
     jsonData:
       authType: keys
-      defaultRegion: eu-west-2
-    secureJsonData:
-      accessKey: '<your access key>'
-      secretKey: '<your secret key>'
+      defaultRegion: euu-west-2
       catalog: AwsDataCatalog
       database: '<your athena database>'
       workgroup: '<your athena workgroup>'
+    secureJsonData:
+      accessKey: '<your access key>'
+      secretKey: '<your secret key>'
 ```
 
 ### Using AWS SDK Default and ARN of IAM Role to Assume


### PR DESCRIPTION
This PR moves the 'catalog', 'database', and 'workgroup' keys from 'secureJsonData' to 'jsonData' in the 'Using accessKey and secretKey' example.

When using the existing example the values for those keys are not populated.

The other examples have those keys in 'jsonData' also.