### PR TITLE
chore: replace GetSession with GetSessionWithAuthSettings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.0
 require (
 	github.com/aws/aws-sdk-go v1.51.31
 	github.com/google/go-cmp v0.6.0
-	github.com/grafana/grafana-aws-sdk v0.26.0
+	github.com/grafana/grafana-aws-sdk v0.27.0
 	github.com/grafana/grafana-plugin-sdk-go v0.228.0
 	github.com/grafana/sqlds/v3 v3.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/grafana/athenadriver v0.0.0-20230518203225-a81b0073ac84 h1:RorAX08zpt
 github.com/grafana/athenadriver v0.0.0-20230518203225-a81b0073ac84/go.mod h1:RnKD7+9Aup8iuFfhK+I26U+z137IXWeoLaEZDepd0Eg=
 github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6kE/MWfg7s=
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
-github.com/grafana/grafana-aws-sdk v0.26.0 h1:pPgORor7FifzsOPZFUYgYVXaUhrOtHYI5WFtQrbfudo=
-github.com/grafana/grafana-aws-sdk v0.26.0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
+github.com/grafana/grafana-aws-sdk v0.27.0 h1:i8YWYr2S0/xKvSlltDEJBnTz5bWYz4vpiNPt9hcJ1Qs=
+github.com/grafana/grafana-aws-sdk v0.27.0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
 github.com/grafana/grafana-plugin-sdk-go v0.228.0 h1:LlPqyB+RZTtDy8RVYD7iQVJW5A0gMoGSI/+Ykz8HebQ=
 github.com/grafana/grafana-plugin-sdk-go v0.228.0/go.mod h1:u4K9vVN6eU86loO68977eTXGypC4brUCnk4sfDzutZU=
 github.com/grafana/sqlds/v3 v3.2.0 h1:WXuYEaFfiCvgm8kK2ixx44/zAEjFzCylA2+RF3GBqZA=

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -37,11 +37,12 @@ func New(ctx context.Context, sessionCache *awsds.SessionCache, settings sqlMode
 		return nil, err
 	}
 
-	sess, err := sessionCache.GetSession(awsds.SessionConfig{
+	authSettings, _ := awsds.ReadAuthSettingsFromContext(ctx)
+	sess, err := sessionCache.GetSessionWithAuthSettings(awsds.GetSessionConfig{
 		HTTPClient:    httpClient,
 		Settings:      athenaSettings.AWSDatasourceSettings,
 		UserAgentName: aws.String("Athena"),
-	})
+	}, *authSettings)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates athena-datasource to make use of https://github.com/grafana/grafana-aws-sdk/pull/144.

I don't see any other necessary multitenancy changes, besides the known issue with temporary credentials.