### PR TITLE
Migrate to new form styling in config and query editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",
-    "@grafana/aws-sdk": "0.3.5",
+    "@grafana/aws-sdk": "0.4.0",
     "@grafana/e2e": "10.3.6",
     "@grafana/e2e-selectors": "10.3.6",
     "@grafana/eslint-config": "^7.0.0",

--- a/src/ConfigEditor.test.tsx
+++ b/src/ConfigEditor.test.tsx
@@ -10,190 +10,167 @@ import userEvent from '@testing-library/user-event';
 
 const resourceName = 'foo';
 const props = mockDatasourceOptions;
-const originalFormFeatureToggleValue = runtime.config.featureToggles.awsDatasourcesNewFormStyling;
 
 const setUpMockBackendServer = (mockBackendSrv: { put: () => void; post: () => void }) => {
   jest.spyOn(runtime, 'getBackendSrv').mockImplementation(() => mockBackendSrv as unknown as runtime.BackendSrv);
 };
-const cleanup = () => {
-  runtime.config.featureToggles.awsDatasourcesNewFormStyling = originalFormFeatureToggleValue;
-};
+
 describe('ConfigEditor', () => {
-  function run() {
-    it('should save and request catalogs', async () => {
-      setUpMockBackendServer({
-        put: jest.fn().mockResolvedValue({ datasource: {} }),
-        post: jest.fn().mockResolvedValue([resourceName]),
-      });
-
-      const onChange = jest.fn();
-      render(<ConfigEditor {...props} onOptionsChange={onChange} />);
-
-      const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.catalog.input);
-      expect(selectEl).toBeInTheDocument();
-
-      await waitFor(() => select(selectEl, resourceName, { container: document.body }));
-
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        jsonData: { ...props.options.jsonData, catalog: resourceName },
-      });
+  it('should save and request catalogs', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue([resourceName]),
     });
 
-    it('should save and request databases', async () => {
-      setUpMockBackendServer({
-        put: jest.fn().mockResolvedValue({ datasource: {} }),
-        post: jest.fn().mockResolvedValue([resourceName]),
-      });
+    const onChange = jest.fn();
+    render(<ConfigEditor {...props} onOptionsChange={onChange} />);
 
-      const onChange = jest.fn();
-      render(<ConfigEditor {...props} onOptionsChange={onChange} />);
+    const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.catalog.input);
+    expect(selectEl).toBeInTheDocument();
 
-      const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.database.input);
-      expect(selectEl).toBeInTheDocument();
+    await waitFor(() => select(selectEl, resourceName, { container: document.body }));
 
-      await waitFor(() => select(selectEl, resourceName, { container: document.body }));
-
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        jsonData: { ...props.options.jsonData, database: resourceName },
-      });
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      jsonData: { ...props.options.jsonData, catalog: resourceName },
     });
-
-    it('should save and request workgroups', async () => {
-      setUpMockBackendServer({
-        put: jest.fn().mockResolvedValue({ datasource: {} }),
-        post: jest.fn().mockResolvedValue([resourceName]),
-      });
-
-      const onChange = jest.fn();
-      render(<ConfigEditor {...props} onOptionsChange={onChange} />);
-
-      const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.workgroup.input);
-      expect(selectEl).toBeInTheDocument();
-
-      await waitFor(() => select(selectEl, resourceName, { container: document.body }));
-
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        jsonData: { ...props.options.jsonData, workgroup: resourceName },
-      });
-    });
-
-    it('should use an output location', async () => {
-      setUpMockBackendServer({
-        put: jest.fn().mockResolvedValue({ datasource: {} }),
-        post: jest.fn().mockResolvedValue([resourceName]),
-      });
-
-      const onChange = jest.fn();
-      render(<ConfigEditor {...props} onOptionsChange={onChange} />);
-      const input = screen.getByTestId(selectors.components.ConfigEditor.OutputLocation.wrapper);
-      const bucket = 's3://foo';
-      fireEvent.change(input, { target: { value: bucket } });
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        jsonData: { ...props.options.jsonData, outputLocation: bucket },
-      });
-    });
-
-    it('should fetch and display externalId when the auth type is grafana_assume_role', async () => {
-      setUpMockBackendServer({
-        put: jest.fn().mockResolvedValue({ datasource: {} }),
-        post: jest.fn().mockResolvedValue({ externalId: 'fake-external-id' }),
-      });
-
-      render(
-        <ConfigEditor
-          {...props}
-          options={{
-            ...props.options,
-            jsonData: {
-              ...props.options.jsonData,
-              authType: AwsAuthType.GrafanaAssumeRole,
-            },
-          }}
-        />
-      );
-
-      expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
-      const instructionsButton = await screen.findByRole('button', {
-        name: /How to create an IAM role for grafana to assume/i,
-      });
-      await userEvent.click(instructionsButton);
-      expect(screen.queryByText('fake-external-id')).toBeInTheDocument();
-    });
-
-    it('gracefully handles when the fetch for external id throws an error', async () => {
-      setUpMockBackendServer({
-        put: jest.fn().mockResolvedValue({ datasource: {} }),
-        post: jest.fn().mockRejectedValue('the server exploded for some reason'),
-      });
-
-      render(
-        <ConfigEditor
-          {...props}
-          options={{
-            ...props.options,
-            jsonData: {
-              ...props.options.jsonData,
-              authType: AwsAuthType.GrafanaAssumeRole,
-            },
-          }}
-        />
-      );
-
-      expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
-      const instructionsButton = await screen.findByRole('button', {
-        name: /How to create an IAM role for grafana to assume/i,
-      });
-      await userEvent.click(instructionsButton);
-      expect(screen.queryByText('External Id is currently unavailable')).toBeInTheDocument();
-    });
-
-    it('gracefully handles when the fetch for external id return an empty string', async () => {
-      setUpMockBackendServer({
-        put: jest.fn().mockResolvedValue({ datasource: {} }),
-        post: jest.fn().mockResolvedValue({ externalId: '' }),
-      });
-
-      render(
-        <ConfigEditor
-          {...props}
-          options={{
-            ...props.options,
-            jsonData: {
-              ...props.options.jsonData,
-              authType: AwsAuthType.GrafanaAssumeRole,
-            },
-          }}
-        />
-      );
-
-      expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
-      const instructionsButton = await screen.findByRole('button', {
-        name: /How to create an IAM role for grafana to assume/i,
-      });
-      await userEvent.click(instructionsButton);
-      expect(screen.queryByText('External Id is currently unavailable')).toBeInTheDocument();
-    });
-  }
-  describe('ConfigEditor with awsDatasourcesNewFormStyling feature toggle disabled', () => {
-    beforeAll(() => {
-      runtime.config.featureToggles.awsDatasourcesNewFormStyling = false;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    run();
   });
-  describe('ConfigEditor with awsDatasourcesNewFormStyling feature toggle enabled', () => {
-    beforeAll(() => {
-      runtime.config.featureToggles.awsDatasourcesNewFormStyling = true;
+
+  it('should save and request databases', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue([resourceName]),
     });
-    afterAll(() => {
-      cleanup();
+
+    const onChange = jest.fn();
+    render(<ConfigEditor {...props} onOptionsChange={onChange} />);
+
+    const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.database.input);
+    expect(selectEl).toBeInTheDocument();
+
+    await waitFor(() => select(selectEl, resourceName, { container: document.body }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      jsonData: { ...props.options.jsonData, database: resourceName },
     });
-    run();
+  });
+
+  it('should save and request workgroups', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue([resourceName]),
+    });
+
+    const onChange = jest.fn();
+    render(<ConfigEditor {...props} onOptionsChange={onChange} />);
+
+    const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.workgroup.input);
+    expect(selectEl).toBeInTheDocument();
+
+    await waitFor(() => select(selectEl, resourceName, { container: document.body }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      jsonData: { ...props.options.jsonData, workgroup: resourceName },
+    });
+  });
+
+  it('should use an output location', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue([resourceName]),
+    });
+
+    const onChange = jest.fn();
+    render(<ConfigEditor {...props} onOptionsChange={onChange} />);
+    const input = screen.getByTestId(selectors.components.ConfigEditor.OutputLocation.wrapper);
+    const bucket = 's3://foo';
+    fireEvent.change(input, { target: { value: bucket } });
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      jsonData: { ...props.options.jsonData, outputLocation: bucket },
+    });
+  });
+
+  it('should fetch and display externalId when the auth type is grafana_assume_role', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue({ externalId: 'fake-external-id' }),
+    });
+
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          jsonData: {
+            ...props.options.jsonData,
+            authType: AwsAuthType.GrafanaAssumeRole,
+          },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
+    const instructionsButton = await screen.findByRole('button', {
+      name: /How to create an IAM role for grafana to assume/i,
+    });
+    await userEvent.click(instructionsButton);
+    expect(screen.queryByText('fake-external-id')).toBeInTheDocument();
+  });
+
+  it('gracefully handles when the fetch for external id throws an error', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockRejectedValue('the server exploded for some reason'),
+    });
+
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          jsonData: {
+            ...props.options.jsonData,
+            authType: AwsAuthType.GrafanaAssumeRole,
+          },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
+    const instructionsButton = await screen.findByRole('button', {
+      name: /How to create an IAM role for grafana to assume/i,
+    });
+    await userEvent.click(instructionsButton);
+    expect(screen.queryByText('External Id is currently unavailable')).toBeInTheDocument();
+  });
+
+  it('gracefully handles when the fetch for external id return an empty string', async () => {
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue({ externalId: '' }),
+    });
+
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          jsonData: {
+            ...props.options.jsonData,
+            authType: AwsAuthType.GrafanaAssumeRole,
+          },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
+    const instructionsButton = await screen.findByRole('button', {
+      name: /How to create an IAM role for grafana to assume/i,
+    });
+    await userEvent.click(instructionsButton);
+    expect(screen.queryByText('External Id is currently unavailable')).toBeInTheDocument();
   });
 });

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -1,8 +1,8 @@
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings, GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { AthenaDataSourceOptions, AthenaDataSourceSecureJsonData, AthenaDataSourceSettings, defaultKey } from './types';
-import { config, getBackendSrv } from '@grafana/runtime';
-import { AwsAuthType, ConfigSelect, ConnectionConfig, Divider, InlineInput } from '@grafana/aws-sdk';
+import { getBackendSrv } from '@grafana/runtime';
+import { AwsAuthType, ConfigSelect, ConnectionConfig, Divider } from '@grafana/aws-sdk';
 import { selectors } from 'tests/selectors';
 import { ConfigSection } from '@grafana/experimental';
 import { Field, Input, useStyles2 } from '@grafana/ui';
@@ -17,7 +17,6 @@ export function ConfigEditor(props: Props) {
   const resourcesURL = `${baseURL}/resources`;
   const [saved, setSaved] = useState(!!props.options.jsonData.defaultRegion);
   const [externalId, setExternalId] = useState('');
-  const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
   const styles = useStyles2(getStyles);
 
   const saveOptions = async () => {
@@ -104,84 +103,14 @@ export function ConfigEditor(props: Props) {
 
   return (
     <div className={styles.formStyles}>
-      <ConnectionConfig
-        {...props}
-        onOptionsChange={onOptionsChange}
-        newFormStylingEnabled={newFormStylingEnabled}
-        externalId={externalId}
-      />
-      {newFormStylingEnabled ? (
-        <>
-          <Divider />
-          <ConfigSection title="Athena Details">
-            <Field
-              label={selectors.components.ConfigEditor.catalog.input}
-              htmlFor="catalog"
-              data-testid={selectors.components.ConfigEditor.catalog.wrapper}
-            >
-              <ConfigSelect
-                {...props}
-                id="catalog"
-                value={props.options.jsonData.catalog ?? ''}
-                onChange={onChange('catalog')}
-                fetch={fetchCatalogs}
-                label={selectors.components.ConfigEditor.catalog.input}
-                saveOptions={saveOptions}
-                newFormStylingEnabled={true}
-              />
-            </Field>
-            <Field
-              label={selectors.components.ConfigEditor.database.input}
-              htmlFor="database"
-              data-testid={selectors.components.ConfigEditor.database.wrapper}
-            >
-              <ConfigSelect
-                {...props}
-                id="database"
-                value={props.options.jsonData.database ?? ''}
-                onChange={onChange('database')}
-                fetch={fetchDatabases}
-                label={selectors.components.ConfigEditor.database.input}
-                dependencies={[props.options.jsonData.catalog || '']}
-                saveOptions={saveOptions}
-                newFormStylingEnabled={true}
-              />
-            </Field>
-            <Field
-              label={selectors.components.ConfigEditor.workgroup.input}
-              htmlFor="workgroup"
-              data-testid={selectors.components.ConfigEditor.workgroup.wrapper}
-            >
-              <ConfigSelect
-                {...props}
-                id="workgroup"
-                value={props.options.jsonData.workgroup ?? ''}
-                onChange={onChange('workgroup')}
-                fetch={fetchWorkgroups}
-                label={selectors.components.ConfigEditor.workgroup.input}
-                saveOptions={saveOptions}
-                newFormStylingEnabled={true}
-              />
-            </Field>
-            <Field
-              label={selectors.components.ConfigEditor.OutputLocation.input}
-              description="Optional. If not specified, the default query result location from the Workgroup configuration will be used."
-              htmlFor="outputLocation"
-            >
-              <Input
-                {...inputProps}
-                id="outputLocation"
-                placeholder="s3://"
-                value={props.options.jsonData.outputLocation ?? ''}
-                onChange={onChangeOutputLocation}
-                data-testid={selectors.components.ConfigEditor.OutputLocation.wrapper}
-              />
-            </Field>
-          </ConfigSection>
-        </>
-      ) : (
-        <>
-          <h3>Athena Details</h3>
+      <ConnectionConfig {...props} onOptionsChange={onOptionsChange} externalId={externalId} />
+      <Divider />
+      <ConfigSection title="Athena Details">
+        <Field
+          label={selectors.components.ConfigEditor.catalog.input}
+          htmlFor="catalog"
+          data-testid={selectors.components.ConfigEditor.catalog.wrapper}
+        >
           <ConfigSelect
             {...props}
             id="catalog"
@@ -189,9 +118,14 @@ export function ConfigEditor(props: Props) {
             onChange={onChange('catalog')}
             fetch={fetchCatalogs}
             label={selectors.components.ConfigEditor.catalog.input}
-            data-testid={selectors.components.ConfigEditor.catalog.wrapper}
             saveOptions={saveOptions}
           />
+        </Field>
+        <Field
+          label={selectors.components.ConfigEditor.database.input}
+          htmlFor="database"
+          data-testid={selectors.components.ConfigEditor.database.wrapper}
+        >
           <ConfigSelect
             {...props}
             id="database"
@@ -199,10 +133,15 @@ export function ConfigEditor(props: Props) {
             onChange={onChange('database')}
             fetch={fetchDatabases}
             label={selectors.components.ConfigEditor.database.input}
-            data-testid={selectors.components.ConfigEditor.database.wrapper}
             dependencies={[props.options.jsonData.catalog || '']}
             saveOptions={saveOptions}
           />
+        </Field>
+        <Field
+          label={selectors.components.ConfigEditor.workgroup.input}
+          htmlFor="workgroup"
+          data-testid={selectors.components.ConfigEditor.workgroup.wrapper}
+        >
           <ConfigSelect
             {...props}
             id="workgroup"
@@ -210,20 +149,24 @@ export function ConfigEditor(props: Props) {
             onChange={onChange('workgroup')}
             fetch={fetchWorkgroups}
             label={selectors.components.ConfigEditor.workgroup.input}
-            data-testid={selectors.components.ConfigEditor.workgroup.wrapper}
             saveOptions={saveOptions}
           />
-          <InlineInput
-            {...props}
+        </Field>
+        <Field
+          label={selectors.components.ConfigEditor.OutputLocation.input}
+          description="Optional. If not specified, the default query result location from the Workgroup configuration will be used."
+          htmlFor="outputLocation"
+        >
+          <Input
+            {...inputProps}
+            id="outputLocation"
+            placeholder="s3://"
             value={props.options.jsonData.outputLocation ?? ''}
             onChange={onChangeOutputLocation}
-            label={selectors.components.ConfigEditor.OutputLocation.input}
             data-testid={selectors.components.ConfigEditor.OutputLocation.wrapper}
-            tooltip="Optional. If not specified, the default query result location from the Workgroup configuration will be used."
-            placeholder="s3://"
           />
-        </>
-      )}
+        </Field>
+      </ConfigSection>
     </div>
   );
 }

--- a/src/QueryEditorForm.test.tsx
+++ b/src/QueryEditorForm.test.tsx
@@ -7,13 +7,10 @@ import '@testing-library/jest-dom';
 import { select } from 'react-select-event';
 import { selectors } from 'tests/selectors';
 import { defaultKey, defaultQuery } from 'types';
-import * as runtime from '@grafana/runtime';
 import * as experimental from '@grafana/experimental';
-import { config } from '@grafana/runtime';
 
 const ds = mockDatasource;
 const q = mockQuery;
-const originalFormFeatureToggleValue = runtime.config.featureToggles.awsDatasourcesNewFormStyling;
 
 const mockGetVariables = jest.fn().mockReturnValue([]);
 
@@ -26,24 +23,11 @@ jest.mock('@grafana/experimental', () => ({
   },
 }));
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual<typeof runtime>('@grafana/runtime'),
-  config: {
-    featureToggles: {
-      awsDatasourcesNewFormStyling: false,
-    },
-  },
-}));
-
 const props = {
   datasource: ds,
   query: q,
   onChange: jest.fn(),
   onRunQuery: jest.fn(),
-};
-
-const cleanup = () => {
-  runtime.config.featureToggles.awsDatasourcesNewFormStyling = originalFormFeatureToggleValue;
 };
 
 beforeEach(() => {
@@ -52,163 +36,141 @@ beforeEach(() => {
 });
 
 describe('QueryEditor', () => {
-  function run() {
-    it('should request regions and use a new one', async () => {
-      const onChange = jest.fn();
-      ds.getResource = jest.fn().mockResolvedValue([ds.defaultRegion, 'foo']);
-      ds.getRegions = jest.fn(() => ds.getResource('regions'));
-      render(<QueryEditorForm {...props} onChange={onChange} />);
+  it('should request regions and use a new one', async () => {
+    const onChange = jest.fn();
+    ds.getResource = jest.fn().mockResolvedValue([ds.defaultRegion, 'foo']);
+    ds.getRegions = jest.fn(() => ds.getResource('regions'));
+    render(<QueryEditorForm {...props} onChange={onChange} />);
 
-      const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.region.input);
-      expect(selectEl).toBeInTheDocument();
-      await userEvent.click(selectEl);
+    const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.region.input);
+    expect(selectEl).toBeInTheDocument();
+    await userEvent.click(selectEl);
 
-      await select(selectEl, 'foo', { container: document.body });
+    await select(selectEl, 'foo', { container: document.body });
 
-      expect(ds.getResource).toHaveBeenCalledWith('regions');
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        connectionArgs: { ...q.connectionArgs, region: 'foo' },
-      });
+    expect(ds.getResource).toHaveBeenCalledWith('regions');
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      connectionArgs: { ...q.connectionArgs, region: 'foo' },
     });
-
-    it('should request catalogs and use a new one', async () => {
-      const onChange = jest.fn();
-      ds.postResource = jest.fn().mockResolvedValue([ds.defaultCatalog, 'foo']);
-      ds.getCatalogs = jest.fn((query) => ds.postResource('catalogs', { region: query.connectionArgs.region }));
-      render(<QueryEditorForm {...props} onChange={onChange} />);
-
-      const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.catalog.input);
-      expect(selectEl).toBeInTheDocument();
-      await userEvent.click(selectEl);
-
-      await select(selectEl, 'foo', { container: document.body });
-
-      expect(ds.postResource).toHaveBeenCalledWith('catalogs', { region: defaultKey });
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        connectionArgs: { ...q.connectionArgs, catalog: 'foo' },
-      });
-    });
-
-    it('should request databases and not execute the query', async () => {
-      const onChange = jest.fn();
-      const onRunQuery = jest.fn();
-      ds.postResource = jest.fn().mockResolvedValue([ds.defaultDatabase, 'foo']);
-      ds.getDatabases = jest.fn((query) =>
-        ds.postResource('databases', { region: query.connectionArgs.region, catalog: query.connectionArgs.catalog })
-      );
-      render(<QueryEditorForm {...props} onChange={onChange} onRunQuery={onRunQuery} />);
-
-      const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.database.input);
-      expect(selectEl).toBeInTheDocument();
-      await userEvent.click(selectEl);
-
-      await select(selectEl, 'foo', { container: document.body });
-
-      expect(ds.postResource).toHaveBeenCalledWith('databases', { region: defaultKey, catalog: defaultKey });
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        connectionArgs: { ...q.connectionArgs, database: 'foo' },
-      });
-      expect(onRunQuery).not.toHaveBeenCalled();
-    });
-
-    it('should request select tables and not execute the query', async () => {
-      const onChange = jest.fn();
-      const onRunQuery = jest.fn();
-      ds.postResource = jest.fn().mockResolvedValue(['foo']);
-      ds.getTables = jest.fn((query) =>
-        ds.postResource('tables', {
-          region: query.connectionArgs.region,
-          catalog: query.connectionArgs.catalog,
-          database: query.connectionArgs.database,
-        })
-      );
-      render(<QueryEditorForm {...props} onChange={onChange} onRunQuery={onRunQuery} />);
-
-      const selectEl = screen.getByLabelText('Table');
-      expect(selectEl).toBeInTheDocument();
-
-      await select(selectEl, 'foo', { container: document.body });
-
-      expect(ds.postResource).toHaveBeenCalledWith(
-        'tables',
-        expect.objectContaining({ region: defaultKey, catalog: defaultKey, database: defaultKey })
-      );
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        table: 'foo',
-      });
-      expect(onRunQuery).not.toHaveBeenCalled();
-    });
-
-    it('should request select columns and not execute the query', async () => {
-      const onChange = jest.fn();
-      const onRunQuery = jest.fn();
-      ds.postResource = jest.fn().mockResolvedValue(['columnName']);
-      ds.getColumns = jest.fn((query) =>
-        ds.postResource('columns', {
-          region: query.connectionArgs.region,
-          catalog: query.connectionArgs.catalog,
-          database: query.connectionArgs.database,
-          table: query.table,
-        })
-      );
-      render(
-        <QueryEditorForm
-          {...props}
-          onChange={onChange}
-          onRunQuery={onRunQuery}
-          query={{ ...props.query, table: 'tableName' }}
-        />
-      );
-
-      const selectEl = screen.getByLabelText('Column');
-      expect(selectEl).toBeInTheDocument();
-
-      await select(selectEl, 'columnName', { container: document.body });
-
-      expect(ds.postResource).toHaveBeenCalledWith(
-        'columns',
-        expect.objectContaining({ region: defaultKey, catalog: defaultKey, database: defaultKey, table: 'tableName' })
-      );
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        column: 'columnName',
-        table: 'tableName',
-      });
-      expect(onRunQuery).not.toHaveBeenCalled();
-    });
-
-    it('should display query options by default', async () => {
-      render(<QueryEditorForm {...props} />);
-      const selectEl = screen.getByLabelText(
-        config.featureToggles.awsDatasourcesNewFormStyling ? 'Format data frames as' : 'Format as'
-      );
-      expect(selectEl).toBeInTheDocument();
-    });
-    it('should update query with defaults on mount', () => {
-      render(<QueryEditorForm {...props} />);
-      expect(props.onChange).toHaveBeenCalledWith({ ...defaultQuery, ...props.query });
-    });
-  }
-  describe('QueryEditorForm with awsDatasourcesNewFormStyling feature toggle disabled', () => {
-    beforeAll(() => {
-      runtime.config.featureToggles.awsDatasourcesNewFormStyling = false;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    run();
   });
-  describe('QueryEditorForm with awsDatasourcesNewFormStyling feature toggle enabled', () => {
-    beforeAll(() => {
-      runtime.config.featureToggles.awsDatasourcesNewFormStyling = true;
+
+  it('should request catalogs and use a new one', async () => {
+    const onChange = jest.fn();
+    ds.postResource = jest.fn().mockResolvedValue([ds.defaultCatalog, 'foo']);
+    ds.getCatalogs = jest.fn((query) => ds.postResource('catalogs', { region: query.connectionArgs.region }));
+    render(<QueryEditorForm {...props} onChange={onChange} />);
+
+    const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.catalog.input);
+    expect(selectEl).toBeInTheDocument();
+    await userEvent.click(selectEl);
+
+    await select(selectEl, 'foo', { container: document.body });
+
+    expect(ds.postResource).toHaveBeenCalledWith('catalogs', { region: defaultKey });
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      connectionArgs: { ...q.connectionArgs, catalog: 'foo' },
     });
-    afterAll(() => {
-      cleanup();
+  });
+
+  it('should request databases and not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.postResource = jest.fn().mockResolvedValue([ds.defaultDatabase, 'foo']);
+    ds.getDatabases = jest.fn((query) =>
+      ds.postResource('databases', { region: query.connectionArgs.region, catalog: query.connectionArgs.catalog })
+    );
+    render(<QueryEditorForm {...props} onChange={onChange} onRunQuery={onRunQuery} />);
+
+    const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.database.input);
+    expect(selectEl).toBeInTheDocument();
+    await userEvent.click(selectEl);
+
+    await select(selectEl, 'foo', { container: document.body });
+
+    expect(ds.postResource).toHaveBeenCalledWith('databases', { region: defaultKey, catalog: defaultKey });
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      connectionArgs: { ...q.connectionArgs, database: 'foo' },
     });
-    run();
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('should request select tables and not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.postResource = jest.fn().mockResolvedValue(['foo']);
+    ds.getTables = jest.fn((query) =>
+      ds.postResource('tables', {
+        region: query.connectionArgs.region,
+        catalog: query.connectionArgs.catalog,
+        database: query.connectionArgs.database,
+      })
+    );
+    render(<QueryEditorForm {...props} onChange={onChange} onRunQuery={onRunQuery} />);
+
+    const selectEl = screen.getByLabelText('Table');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'foo', { container: document.body });
+
+    expect(ds.postResource).toHaveBeenCalledWith(
+      'tables',
+      expect.objectContaining({ region: defaultKey, catalog: defaultKey, database: defaultKey })
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      table: 'foo',
+    });
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('should request select columns and not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.postResource = jest.fn().mockResolvedValue(['columnName']);
+    ds.getColumns = jest.fn((query) =>
+      ds.postResource('columns', {
+        region: query.connectionArgs.region,
+        catalog: query.connectionArgs.catalog,
+        database: query.connectionArgs.database,
+        table: query.table,
+      })
+    );
+    render(
+      <QueryEditorForm
+        {...props}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+        query={{ ...props.query, table: 'tableName' }}
+      />
+    );
+
+    const selectEl = screen.getByLabelText('Column');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'columnName', { container: document.body });
+
+    expect(ds.postResource).toHaveBeenCalledWith(
+      'columns',
+      expect.objectContaining({ region: defaultKey, catalog: defaultKey, database: defaultKey, table: 'tableName' })
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      column: 'columnName',
+      table: 'tableName',
+    });
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('should display query options by default', async () => {
+    render(<QueryEditorForm {...props} />);
+    const selectEl = screen.getByLabelText('Format data frames as');
+    expect(selectEl).toBeInTheDocument();
+  });
+  it('should update query with defaults on mount', () => {
+    render(<QueryEditorForm {...props} />);
+    expect(props.onChange).toHaveBeenCalledWith({ ...defaultQuery, ...props.query });
   });
 });

--- a/src/QueryEditorForm.tsx
+++ b/src/QueryEditorForm.tsx
@@ -3,14 +3,13 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './datasource';
 import { AthenaDataSourceOptions, AthenaQuery, defaultQuery, SelectableFormatOptions } from './types';
-import { CollapsableSection, InlineSegmentGroup, useStyles2 } from '@grafana/ui';
+import { CollapsableSection, useStyles2 } from '@grafana/ui';
 import { FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
 import { selectors } from 'tests/selectors';
 import { appendTemplateVariables } from 'utils';
 import SQLEditor from 'SQLEditor';
 import { ResultReuse } from 'ResultReuse/ResultReuse';
 import { EditorField, EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
-import { config } from '@grafana/runtime';
 
 type Props = QueryEditorProps<DataSource, AthenaQuery, AthenaDataSourceOptions> & {
   hideOptions?: boolean;
@@ -21,7 +20,6 @@ type QueryProperties = 'regions' | 'catalogs' | 'databases' | 'tables' | 'column
 export function QueryEditorForm(props: Props) {
   const [resultReuseSupported, setResultReuseSupported] = useState(false);
   const styles = useStyles2(getStyles);
-  const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
 
   useEffect(() => {
     const getIsResultReuseSupported = async () => {
@@ -88,144 +86,15 @@ export function QueryEditorForm(props: Props) {
   };
 
   return (
-    <>
-      {newFormStylingEnabled ? (
-        <EditorRows>
-          <EditorRow>
-            <EditorFieldGroup>
-              <EditorField
-                width={15}
-                label={selectors.components.ConfigEditor.region.input}
-                data-testid={selectors.components.ConfigEditor.region.wrapper}
-                htmlFor="regions"
-              >
-                <ResourceSelector
-                  id="regions"
-                  onChange={onChange('regions')}
-                  fetch={fetchRegions}
-                  value={queryWithDefaults.connectionArgs.region ?? null}
-                  default={props.datasource.defaultRegion}
-                  label={selectors.components.ConfigEditor.region.input}
-                  newFormStylingEnabled
-                />
-              </EditorField>
-              <EditorField
-                width={15}
-                label={selectors.components.ConfigEditor.catalog.input}
-                data-testid={selectors.components.ConfigEditor.catalog.wrapper}
-                htmlFor="catalogs"
-              >
-                <ResourceSelector
-                  id="catalogs"
-                  onChange={onChange('catalogs')}
-                  fetch={fetchCatalogs}
-                  value={queryWithDefaults.connectionArgs.catalog ?? null}
-                  default={props.datasource.defaultCatalog}
-                  dependencies={[queryWithDefaults.connectionArgs.region]}
-                  label={selectors.components.ConfigEditor.catalog.input}
-                  newFormStylingEnabled
-                />
-              </EditorField>
-            </EditorFieldGroup>
-
-            <EditorFieldGroup>
-              <EditorField
-                width={20}
-                label={selectors.components.ConfigEditor.database.input}
-                data-testid={selectors.components.ConfigEditor.database.wrapper}
-                htmlFor="databases"
-              >
-                <ResourceSelector
-                  id="databases"
-                  onChange={onChange('databases')}
-                  fetch={fetchDatabases}
-                  value={queryWithDefaults.connectionArgs.database ?? null}
-                  default={props.datasource.defaultDatabase}
-                  dependencies={[queryWithDefaults.connectionArgs.catalog]}
-                  label={selectors.components.ConfigEditor.database.input}
-                  newFormStylingEnabled
-                />
-              </EditorField>
-              <EditorField
-                width={20}
-                label={selectors.components.ConfigEditor.table.input}
-                data-testid={selectors.components.ConfigEditor.table.wrapper}
-                tooltip="Use the selected table with the $__table macro"
-                htmlFor="tables"
-              >
-                <ResourceSelector
-                  id="tables"
-                  onChange={onChange('tables')}
-                  fetch={fetchTables}
-                  value={props.query.table || null}
-                  dependencies={[queryWithDefaults.connectionArgs.database]}
-                  label={selectors.components.ConfigEditor.table.input}
-                  newFormStylingEnabled
-                />
-              </EditorField>
-              <EditorField
-                width={20}
-                label={selectors.components.ConfigEditor.column.input}
-                data-testid={selectors.components.ConfigEditor.column.wrapper}
-                tooltip="Use the selected column with the $__column macro"
-                htmlFor="columns"
-              >
-                <ResourceSelector
-                  id="columns"
-                  label={selectors.components.ConfigEditor.column.input}
-                  onChange={onChange('columns')}
-                  fetch={fetchColumns}
-                  value={props.query.column || null}
-                  dependencies={[queryWithDefaults.table]}
-                  newFormStylingEnabled
-                />
-              </EditorField>
-            </EditorFieldGroup>
-            {!props.hideOptions && (
-              <EditorFieldGroup>
-                <EditorField label="Format data frames as" htmlFor="formatAs" width={20}>
-                  <FormatSelect
-                    newFormStylingEnabled={true}
-                    id="formatAs"
-                    query={props.query}
-                    options={SelectableFormatOptions}
-                    onChange={props.onChange}
-                  />
-                </EditorField>
-              </EditorFieldGroup>
-            )}
-          </EditorRow>
-          <EditorRow>
-            <div className={styles.collapseRow}>
-              {/* temporary solution until we have a collapse section compatible with Editor Fields in grafana/ui */}
-              <CollapsableSection
-                className={styles.collapse}
-                label={
-                  <p className={styles.collapseTitle}>
-                    Query result reuse{' '}
-                    {!resultReuseSupported && <span className={styles.optional}>(engine version 3 only)</span>}
-                  </p>
-                }
-                isOpen={!!props.query.connectionArgs?.resultReuseEnabled}
-              >
-                <ResultReuse
-                  enabled={resultReuseSupported}
-                  query={props.query}
-                  onChange={props.onChange}
-                  newFormStylingEnabled={true}
-                />
-              </CollapsableSection>
-            </div>
-          </EditorRow>
-          <EditorRow>
-            <div style={{ width: '100%' }}>
-              <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
-            </div>
-          </EditorRow>
-        </EditorRows>
-      ) : (
-        <InlineSegmentGroup>
-          <div className="gf-form-group">
+    <EditorRows>
+      <EditorRow>
+        <EditorFieldGroup>
+          <EditorField
+            width={15}
+            label={selectors.components.ConfigEditor.region.input}
+            data-testid={selectors.components.ConfigEditor.region.wrapper}
+            htmlFor="regions"
+          >
             <ResourceSelector
               id="regions"
               onChange={onChange('regions')}
@@ -233,10 +102,14 @@ export function QueryEditorForm(props: Props) {
               value={queryWithDefaults.connectionArgs.region ?? null}
               default={props.datasource.defaultRegion}
               label={selectors.components.ConfigEditor.region.input}
-              data-testid={selectors.components.ConfigEditor.region.wrapper}
-              labelWidth={11}
-              className="width-12"
             />
+          </EditorField>
+          <EditorField
+            width={15}
+            label={selectors.components.ConfigEditor.catalog.input}
+            data-testid={selectors.components.ConfigEditor.catalog.wrapper}
+            htmlFor="catalogs"
+          >
             <ResourceSelector
               id="catalogs"
               onChange={onChange('catalogs')}
@@ -245,10 +118,17 @@ export function QueryEditorForm(props: Props) {
               default={props.datasource.defaultCatalog}
               dependencies={[queryWithDefaults.connectionArgs.region]}
               label={selectors.components.ConfigEditor.catalog.input}
-              data-testid={selectors.components.ConfigEditor.catalog.wrapper}
-              labelWidth={11}
-              className="width-12"
             />
+          </EditorField>
+        </EditorFieldGroup>
+
+        <EditorFieldGroup>
+          <EditorField
+            width={20}
+            label={selectors.components.ConfigEditor.database.input}
+            data-testid={selectors.components.ConfigEditor.database.wrapper}
+            htmlFor="databases"
+          >
             <ResourceSelector
               id="databases"
               onChange={onChange('databases')}
@@ -257,49 +137,77 @@ export function QueryEditorForm(props: Props) {
               default={props.datasource.defaultDatabase}
               dependencies={[queryWithDefaults.connectionArgs.catalog]}
               label={selectors.components.ConfigEditor.database.input}
-              data-testid={selectors.components.ConfigEditor.database.wrapper}
-              labelWidth={11}
-              className="width-12"
             />
+          </EditorField>
+          <EditorField
+            width={20}
+            label={selectors.components.ConfigEditor.table.input}
+            data-testid={selectors.components.ConfigEditor.table.wrapper}
+            tooltip="Use the selected table with the $__table macro"
+            htmlFor="tables"
+          >
             <ResourceSelector
               id="tables"
               onChange={onChange('tables')}
               fetch={fetchTables}
               value={props.query.table || null}
               dependencies={[queryWithDefaults.connectionArgs.database]}
-              tooltip="Use the selected table with the $__table macro"
               label={selectors.components.ConfigEditor.table.input}
-              data-testid={selectors.components.ConfigEditor.table.wrapper}
-              labelWidth={11}
-              className="width-12"
             />
+          </EditorField>
+          <EditorField
+            width={20}
+            label={selectors.components.ConfigEditor.column.input}
+            data-testid={selectors.components.ConfigEditor.column.wrapper}
+            tooltip="Use the selected column with the $__column macro"
+            htmlFor="columns"
+          >
             <ResourceSelector
               id="columns"
+              label={selectors.components.ConfigEditor.column.input}
               onChange={onChange('columns')}
               fetch={fetchColumns}
               value={props.query.column || null}
               dependencies={[queryWithDefaults.table]}
-              tooltip="Use the selected column with the $__column macro"
-              label={selectors.components.ConfigEditor.column.input}
-              data-testid={selectors.components.ConfigEditor.column.wrapper}
-              labelWidth={11}
-              className="width-12"
             />
+          </EditorField>
+        </EditorFieldGroup>
+        {!props.hideOptions && (
+          <EditorFieldGroup>
+            <EditorField label="Format data frames as" htmlFor="formatAs" width={20}>
+              <FormatSelect
+                id="formatAs"
+                query={props.query}
+                options={SelectableFormatOptions}
+                onChange={props.onChange}
+              />
+            </EditorField>
+          </EditorFieldGroup>
+        )}
+      </EditorRow>
+      <EditorRow>
+        <div className={styles.collapseRow}>
+          {/* temporary solution until we have a collapse section compatible with Editor Fields in grafana/ui */}
+          <CollapsableSection
+            className={styles.collapse}
+            label={
+              <p className={styles.collapseTitle}>
+                Query result reuse{' '}
+                {!resultReuseSupported && <span className={styles.optional}>(engine version 3 only)</span>}
+              </p>
+            }
+            isOpen={!!props.query.connectionArgs?.resultReuseEnabled}
+          >
             <ResultReuse enabled={resultReuseSupported} query={props.query} onChange={props.onChange} />
-            {!props.hideOptions && (
-              <>
-                <h6>Frames</h6>
-                <FormatSelect query={props.query} options={SelectableFormatOptions} onChange={props.onChange} />
-              </>
-            )}
-          </div>
-
-          <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
-            <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
-          </div>
-        </InlineSegmentGroup>
-      )}
-    </>
+          </CollapsableSection>
+        </div>
+      </EditorRow>
+      <EditorRow>
+        <div style={{ width: '100%' }}>
+          <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
+        </div>
+      </EditorRow>
+    </EditorRows>
   );
 }
 

--- a/src/ResultReuse/ResultReuse.test.tsx
+++ b/src/ResultReuse/ResultReuse.test.tsx
@@ -4,87 +4,53 @@ import { ResultReuse } from './ResultReuse';
 import { mockQuery } from '__mocks__/datasource';
 
 describe('ResultReuse', () => {
-  function run(testName: string, newFormStylingEnabled?: boolean) {
-    describe(testName, () => {
-      it('options should be enabled if `enabled=true`', () => {
-        render(
-          <ResultReuse
-            enabled={true}
-            onChange={() => {}}
-            query={mockQuery}
-            newFormStylingEnabled={newFormStylingEnabled}
-          />
-        );
-        const toggle = screen.getByLabelText('Enable');
-        const ttlInput = screen.getByLabelText('TTL (mins)');
+  it('options should be enabled if `enabled=true`', () => {
+    render(<ResultReuse enabled={true} onChange={() => {}} query={mockQuery} />);
+    const toggle = screen.getByLabelText('Enable');
+    const ttlInput = screen.getByLabelText('TTL (mins)');
 
-        expect(toggle).toBeEnabled();
-        expect(ttlInput).toBeEnabled();
-      });
+    expect(toggle).toBeEnabled();
+    expect(ttlInput).toBeEnabled();
+  });
 
-      it('options should be disabled if `enabled=false`', () => {
-        render(
-          <ResultReuse
-            enabled={false}
-            onChange={() => {}}
-            query={mockQuery}
-            newFormStylingEnabled={newFormStylingEnabled}
-          />
-        );
-        const toggle = screen.getByLabelText('Enable');
-        const ttlInput = screen.getByLabelText('TTL (mins)');
+  it('options should be disabled if `enabled=false`', () => {
+    render(<ResultReuse enabled={false} onChange={() => {}} query={mockQuery} />);
+    const toggle = screen.getByLabelText('Enable');
+    const ttlInput = screen.getByLabelText('TTL (mins)');
 
-        expect(toggle).toBeDisabled();
-        expect(ttlInput).toBeDisabled();
-      });
+    expect(toggle).toBeDisabled();
+    expect(ttlInput).toBeDisabled();
+  });
 
-      it('should call `onChange` when toggle is clicked', () => {
-        const onChange = jest.fn();
-        render(
-          <ResultReuse
-            enabled={true}
-            onChange={onChange}
-            query={mockQuery}
-            newFormStylingEnabled={newFormStylingEnabled}
-          />
-        );
-        const toggle = screen.getByLabelText('Enable');
+  it('should call `onChange` when toggle is clicked', () => {
+    const onChange = jest.fn();
+    render(<ResultReuse enabled={true} onChange={onChange} query={mockQuery} />);
+    const toggle = screen.getByLabelText('Enable');
 
-        fireEvent.click(toggle);
+    fireEvent.click(toggle);
 
-        expect(onChange).toHaveBeenCalledWith({
-          ...mockQuery,
-          connectionArgs: {
-            ...mockQuery.connectionArgs,
-            resultReuseEnabled: true,
-          },
-        });
-      });
-
-      it('should call `onChange` when TTL input is changed', () => {
-        const onChange = jest.fn();
-        render(
-          <ResultReuse
-            enabled={true}
-            onChange={onChange}
-            query={mockQuery}
-            newFormStylingEnabled={newFormStylingEnabled}
-          />
-        );
-        const ttlInput = screen.getByLabelText('TTL (mins)');
-
-        fireEvent.change(ttlInput, { target: { value: '10' } });
-
-        expect(onChange).toHaveBeenCalledWith({
-          ...mockQuery,
-          connectionArgs: {
-            ...mockQuery.connectionArgs,
-            resultReuseMaxAgeInMinutes: 10,
-          },
-        });
-      });
+    expect(onChange).toHaveBeenCalledWith({
+      ...mockQuery,
+      connectionArgs: {
+        ...mockQuery.connectionArgs,
+        resultReuseEnabled: true,
+      },
     });
-  }
-  run('ResultReuse with awsDatasourcesNewFormStyling disabled', false);
-  run('ResultReuse with awsDatasourcesNewFormStyling enabled', true);
+  });
+
+  it('should call `onChange` when TTL input is changed', () => {
+    const onChange = jest.fn();
+    render(<ResultReuse enabled={true} onChange={onChange} query={mockQuery} />);
+    const ttlInput = screen.getByLabelText('TTL (mins)');
+
+    fireEvent.change(ttlInput, { target: { value: '10' } });
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...mockQuery,
+      connectionArgs: {
+        ...mockQuery.connectionArgs,
+        resultReuseMaxAgeInMinutes: 10,
+      },
+    });
+  });
 });

--- a/src/ResultReuse/ResultReuse.tsx
+++ b/src/ResultReuse/ResultReuse.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
-import { Checkbox, InlineField, Input, Switch } from '@grafana/ui';
+import { Input, Switch } from '@grafana/ui';
 import { AthenaQuery, DEFAULT_RESULT_REUSE_ENABLED, DEFAULT_RESULT_REUSE_MAX_AGE_IN_MINUTES } from '../types';
 import { EditorField } from '@grafana/experimental';
 import { css } from '@emotion/css';
 
 interface ResultReuseProps {
   query: AthenaQuery;
-  newFormStylingEnabled?: boolean;
   enabled?: boolean;
   onChange: (value: AthenaQuery) => void;
 }
 
-export const ResultReuse = ({ enabled, onChange, query, newFormStylingEnabled }: ResultReuseProps) => {
+export const ResultReuse = ({ enabled, onChange, query }: ResultReuseProps) => {
   const {
     connectionArgs: {
       resultReuseEnabled = DEFAULT_RESULT_REUSE_ENABLED,
@@ -45,65 +44,28 @@ export const ResultReuse = ({ enabled, onChange, query, newFormStylingEnabled }:
   const invalidResultReuseMaxAgeInMinutes = resultReuseMaxAgeInMinutes < 0 || resultReuseMaxAgeInMinutes > 10080;
 
   return (
-    <>
-      {newFormStylingEnabled ? (
-        <div className={css({display: 'flex'})}>
-          <EditorField className="width-5" disabled={!enabled} label="Enable" htmlFor="query-result-reuse-toggle">
-            <Switch
-              id="query-result-reuse-toggle"
-              value={resultReuseEnabled && enabled}
-              onChange={handleEnabledChange}
-            />
-          </EditorField>
-          <EditorField
-            className="width-10"
-            disabled={!enabled}
-            invalid={invalidResultReuseMaxAgeInMinutes}
-            label="TTL (mins)"
-            htmlFor="query-result-reuse-ttl"
-            tooltip="The maximum age for reusing query results in minutes. Minimum 0, maximum 10080."
-          >
-            <Input
-              id="query-result-reuse-ttl"
-              min={0}
-              max={10080}
-              onChange={handleTTLChange}
-              onBlur={handleTTLChange}
-              type="number"
-              value={resultReuseMaxAgeInMinutes}
-            />
-          </EditorField>
-        </div>
-      ) : (
-        <>
-          <InlineField labelWidth={13} disabled={!enabled} label="Enable" aria-label="Enable query result reuse">
-            <Checkbox
-              id="query-result-reuse-toggle"
-              onChange={handleEnabledChange}
-              value={resultReuseEnabled && enabled}
-            />
-          </InlineField>
-          <InlineField
-            labelWidth={13}
-            disabled={!enabled}
-            invalid={invalidResultReuseMaxAgeInMinutes}
-            label="TTL (mins)"
-            aria-label="Max age in minutes"
-            tooltip="The maximum age for reusing query results in minutes. Minimum 0, maximum 10080."
-          >
-            <Input
-              id="query-result-reuse-ttl"
-              className="width-11"
-              min={0}
-              max={10080}
-              onChange={handleTTLChange}
-              onBlur={handleTTLChange}
-              type="number"
-              value={resultReuseMaxAgeInMinutes}
-            />
-          </InlineField>
-        </>
-      )}
-    </>
+    <div className={css({ display: 'flex' })}>
+      <EditorField className="width-5" disabled={!enabled} label="Enable" htmlFor="query-result-reuse-toggle">
+        <Switch id="query-result-reuse-toggle" value={resultReuseEnabled && enabled} onChange={handleEnabledChange} />
+      </EditorField>
+      <EditorField
+        className="width-10"
+        disabled={!enabled}
+        invalid={invalidResultReuseMaxAgeInMinutes}
+        label="TTL (mins)"
+        htmlFor="query-result-reuse-ttl"
+        tooltip="The maximum age for reusing query results in minutes. Minimum 0, maximum 10080."
+      >
+        <Input
+          id="query-result-reuse-ttl"
+          min={0}
+          max={10080}
+          onChange={handleTTLChange}
+          onBlur={handleTTLChange}
+          type="number"
+          value={resultReuseMaxAgeInMinutes}
+        />
+      </EditorField>
+    </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1697,10 +1697,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.3.5.tgz#eadf9a608016bc2dc093a80ec5ffbba4dd6fa489"
-  integrity sha512-WzB5uRIlzF0u6YRC7JbzeORbLNPZIZBpZoNkgobka2kranQHD/iJpdcYuVhyfI9Ca+lcTej9fPKnaUOnR2dlnQ==
+"@grafana/aws-sdk@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.4.0.tgz#bc5192c48b47ca0911ba2ac777923abd337d1074"
+  integrity sha512-42OBqjb0zgEy1jgteg8llkz55p0r0GZGYxzxfLXHpqGQwqkextUO+axlGjRuylKl50d+XArZEvUNj4JWRGp23w==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
     "@grafana/experimental" "1.7.0"


### PR DESCRIPTION
Removes the newFormStyling feature toggle, making the new styling default. Part of https://github.com/grafana/oss-plugin-partnerships/issues/692