### PR TITLE
Fix: use ReadAuthSettings to get authSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.16.2
+
+- Fix: use ReadAuthSettings to get authSettings in [#339](https://github.com/grafana/athena-datasource/pull/339)
+
 ## 2.16.1
 
 - Chore: update dependencies in [#332](https://github.com/grafana/athena-datasource/pull/332)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -37,7 +37,7 @@ func New(ctx context.Context, sessionCache *awsds.SessionCache, settings sqlMode
 		return nil, err
 	}
 
-	authSettings, _ := awsds.ReadAuthSettingsFromContext(ctx)
+	authSettings := awsds.ReadAuthSettings(ctx)
 	sess, err := sessionCache.GetSessionWithAuthSettings(awsds.GetSessionConfig{
 		HTTPClient:    httpClient,
 		Settings:      athenaSettings.AWSDatasourceSettings,


### PR DESCRIPTION
Fixes: https://github.com/grafana/athena-datasource/issues/338

Uses `ReadAuthSettings` which tries to read auth settings from context first and then automatically falls back to reading auth settings from the environment.

Also includes the changes for releasing these changes.