### PR TITLE
Prepare 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.17.0
+
+-  Migrate to new form styling in config and query editors  in [#337](https://github.com/grafana/athena-datasource/pull/337)
+
 ## 2.16.2
 
 - Fix: use ReadAuthSettings to get authSettings in [#339](https://github.com/grafana/athena-datasource/pull/339)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.16.2",
+  "version": "2.17.0",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## 2.17.0

-  Migrate to new form styling in config and query editors  in [#337](https://github.com/grafana/athena-datasource/pull/337)