### PR TITLE
Start adding errorsource

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -8,7 +8,8 @@
     "src/dashboards/**",
     "yarn.lock",
     "go.sum",
-    "mage_output_file.go"
+    "mage_output_file.go",
+    "go.mod",
   ],
   "words": [
     "athenaclientmock",

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -20,6 +20,7 @@
     "datasource",
     "datasources",
     "datetime",
+    "errorsource",
     "eventtime",
     "fridgepoet",
     "gotest",

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.0
 require (
 	github.com/aws/aws-sdk-go v1.51.31
 	github.com/google/go-cmp v0.6.0
-	github.com/grafana/grafana-aws-sdk v0.27.0
+	github.com/grafana/grafana-aws-sdk v0.28.1-0.20240716142732-adf2cef95fa0
 	github.com/grafana/grafana-plugin-sdk-go v0.228.0
 	github.com/grafana/sqlds/v3 v3.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.0
 require (
 	github.com/aws/aws-sdk-go v1.51.31
 	github.com/google/go-cmp v0.6.0
-	github.com/grafana/grafana-aws-sdk v0.28.1-0.20240716142732-adf2cef95fa0
+	github.com/grafana/grafana-aws-sdk v0.29.0
 	github.com/grafana/grafana-plugin-sdk-go v0.228.0
 	github.com/grafana/sqlds/v3 v3.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/grafana-aws-sdk v0.27.0 h1:i8YWYr2S0/xKvSlltDEJBnTz5bWYz4vpiNPt9hcJ1Qs=
 github.com/grafana/grafana-aws-sdk v0.27.0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
+github.com/grafana/grafana-aws-sdk v0.28.1-0.20240716142732-adf2cef95fa0 h1:PSOaVzWLDkVLcEV1mV8KvHasgQuanf0DTaUW4/6pXF0=
+github.com/grafana/grafana-aws-sdk v0.28.1-0.20240716142732-adf2cef95fa0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
 github.com/grafana/grafana-plugin-sdk-go v0.228.0 h1:LlPqyB+RZTtDy8RVYD7iQVJW5A0gMoGSI/+Ykz8HebQ=
 github.com/grafana/grafana-plugin-sdk-go v0.228.0/go.mod h1:u4K9vVN6eU86loO68977eTXGypC4brUCnk4sfDzutZU=
 github.com/grafana/sqlds/v3 v3.2.0 h1:WXuYEaFfiCvgm8kK2ixx44/zAEjFzCylA2+RF3GBqZA=

--- a/go.sum
+++ b/go.sum
@@ -86,10 +86,8 @@ github.com/grafana/athenadriver v0.0.0-20230518203225-a81b0073ac84 h1:RorAX08zpt
 github.com/grafana/athenadriver v0.0.0-20230518203225-a81b0073ac84/go.mod h1:RnKD7+9Aup8iuFfhK+I26U+z137IXWeoLaEZDepd0Eg=
 github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6kE/MWfg7s=
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
-github.com/grafana/grafana-aws-sdk v0.27.0 h1:i8YWYr2S0/xKvSlltDEJBnTz5bWYz4vpiNPt9hcJ1Qs=
-github.com/grafana/grafana-aws-sdk v0.27.0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
-github.com/grafana/grafana-aws-sdk v0.28.1-0.20240716142732-adf2cef95fa0 h1:PSOaVzWLDkVLcEV1mV8KvHasgQuanf0DTaUW4/6pXF0=
-github.com/grafana/grafana-aws-sdk v0.28.1-0.20240716142732-adf2cef95fa0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
+github.com/grafana/grafana-aws-sdk v0.29.0 h1:BkyR8iUJlNqmpgw7AD8pxiizXZD2r7t4PE541TTmaps=
+github.com/grafana/grafana-aws-sdk v0.29.0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
 github.com/grafana/grafana-plugin-sdk-go v0.228.0 h1:LlPqyB+RZTtDy8RVYD7iQVJW5A0gMoGSI/+Ykz8HebQ=
 github.com/grafana/grafana-plugin-sdk-go v0.228.0/go.mod h1:u4K9vVN6eU86loO68977eTXGypC4brUCnk4sfDzutZU=
 github.com/grafana/sqlds/v3 v3.2.0 h1:WXuYEaFfiCvgm8kK2ixx44/zAEjFzCylA2+RF3GBqZA=

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -64,7 +64,7 @@ func (c *API) Execute(ctx context.Context, input *api.ExecuteQueryInput) (*api.E
 	version, err := c.WorkgroupEngineVersion(ctx, sqlds.Options{"workgroup": c.settings.WorkGroup})
 
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", api.ExecuteError, err)
+		return nil, errorsource.DownstreamError(fmt.Errorf("%w: %v", api.ExecuteError, err), false)
 	}
 
 	if workgroupEngineSupportsResultReuse(version) {
@@ -84,7 +84,7 @@ func (c *API) Execute(ctx context.Context, input *api.ExecuteQueryInput) (*api.E
 
 	output, err := c.Client.StartQueryExecutionWithContext(ctx, athenaInput)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", api.ExecuteError, err)
+		return nil, errorsource.DownstreamError(fmt.Errorf("%w: %v", api.ExecuteError, err), false)
 	}
 
 	return &api.ExecuteQueryOutput{ID: *output.QueryExecutionId}, nil
@@ -102,7 +102,7 @@ func (c *API) Status(ctx aws.Context, output *api.ExecuteQueryOutput) (*api.Exec
 		QueryExecutionId: aws.String(output.ID),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", api.ExecuteError, err)
+		return nil, errorsource.DownstreamError(fmt.Errorf("%w: %v", api.ExecuteError, err), false)
 	}
 
 	var finished bool


### PR DESCRIPTION
This adds errorsource in a few places, in support of better logging & alerting.

Depends on https://github.com/grafana/grafana-aws-sdk/pull/155, and updating `go.mod` to use the new version.