### PR TITLE
fix: don't check slice nilness before length check

### DIFF
--- a/pkg/athena/models/settings.go
+++ b/pkg/athena/models/settings.go
@@ -36,7 +36,7 @@ func New(_ context.Context) models.Settings {
 }
 
 func (s *AthenaDataSourceSettings) Load(config backend.DataSourceInstanceSettings) error {
-	if config.JSONData != nil && len(config.JSONData) > 1 {
+	if len(config.JSONData) > 1 {
 		if err := json.Unmarshal(config.JSONData, s); err != nil {
 			return fmt.Errorf("could not unmarshal DatasourceSettings json: %w", err)
 		}


### PR DESCRIPTION
The latest version of golangci-lint makes this an error, which is why all the recent dependabot PRs are failing.