### PR TITLE
chore: add manual "combine PRs" action

### DIFF
--- a/.github/workflows/combine_prs.yml
+++ b/.github/workflows/combine_prs.yml
@@ -1,0 +1,21 @@
+name: Combine PRs
+
+on:
+  workflow_dispatch: # manual activation, for now
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: combine-prs
+        id: combine-prs
+        uses: github.com/combine-prs@v5.1.0
+        with:
+          labels: combined-pr
+          branch_prefix: dependabot # the default, just for clarity


### PR DESCRIPTION
This adds the "combine PRs" workflow, which will combine all open dependabot PRs (barring merge conflicts) into a single one. This is in support of merging these more regularly.

For now this is set as a manual action. If we decide it's useful we can update it to run weekly.