### PR TITLE
Update combine_prs action with a clearer PR title

### DIFF
--- a/.github/workflows/combine_prs.yml
+++ b/.github/workflows/combine_prs.yml
@@ -18,4 +18,5 @@ jobs:
         uses: github/combine-prs@v5.1.0
         with:
           labels: combined-pr
+          pr_title: "Dependabot updates"
           branch_prefix: dependabot # the default, just for clarity


### PR DESCRIPTION
Makes [the same change as in AMP](https://github.com/grafana/grafana-amazonprometheus-datasource/pull/223):
The current "Combined PRs" title isn't that clear on what's being combined. This title ends up being the default commit message of the squashed commit and ends up in the Changelog..