### PR TITLE
Add @grafana/e2e dependencies to dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - dependency-name: "@grafana/e2e*
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
I'm getting annoyed by all the failing workflows, I think this should do it? Until we add the new e2e stuff at least

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore