### PR TITLE
Mark errors when interpolating macros errors as downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## Unreleased changes
+## 2.17.4
+- Mark errors when interpolating macros errors as downstream in [#410](https://github.com/grafana/athena-datasource/pull/410)
 - Dependabot updates
   - Bump github.com/grafana/grafana-plugin-sdk-go from 0.248.0 to 0.250.0
   - Bump github.com/grafana/grafana-aws-sdk from 0.31.0 to 0.31.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 2.17.4
 - Mark errors when interpolating macros errors as downstream in [#410](https://github.com/grafana/athena-datasource/pull/410)
+- Bump github.com/grafana/grafana-plugin-sdk-go from 0.248.0 to 0.250.2 in [#410](https://github.com/grafana/athena-datasource/pull/410)
 - Dependabot updates
-  - Bump github.com/grafana/grafana-plugin-sdk-go from 0.248.0 to 0.250.0
   - Bump github.com/grafana/grafana-aws-sdk from 0.31.0 to 0.31.2
   - Bump @types/node from 22.5.3 to 22.5.5
   - Bump @babel/core from 7.24.7 to 7.25.2

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/google/go-cmp v0.6.0
 	github.com/grafana/grafana-aws-sdk v0.31.2
-	github.com/grafana/grafana-plugin-sdk-go v0.250.1
+	github.com/grafana/grafana-plugin-sdk-go v0.250.2
 	github.com/grafana/sqlds/v4 v4.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/google/go-cmp v0.6.0
 	github.com/grafana/grafana-aws-sdk v0.31.2
-	github.com/grafana/grafana-plugin-sdk-go v0.250.0
+	github.com/grafana/grafana-plugin-sdk-go v0.250.1
 	github.com/grafana/sqlds/v4 v4.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/grafana/grafana-aws-sdk v0.31.2 h1:Mv01GAHcIG3S2pVtRlt1cUnnWzUAr4qr74
 github.com/grafana/grafana-aws-sdk v0.31.2/go.mod h1:5nt5Gmp6+GyM+Jr7xsXKJtbizxbYXXLmEac6kw5paQI=
 github.com/grafana/grafana-plugin-sdk-go v0.250.0 h1:9EBucp9jLqMx2b8NTlOXH+4OuQWUh6L85c6EJUN8Jdo=
 github.com/grafana/grafana-plugin-sdk-go v0.250.0/go.mod h1:gCGN9kHY3KeX4qyni3+Kead38Q+85pYOrsDcxZp6AIk=
+github.com/grafana/grafana-plugin-sdk-go v0.250.1 h1:cIElucYsy9JZb/9GMXzk0oWJVd3pxuCWCgvPm99UM9w=
+github.com/grafana/grafana-plugin-sdk-go v0.250.1/go.mod h1:gCGN9kHY3KeX4qyni3+Kead38Q+85pYOrsDcxZp6AIk=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/grafana/grafana-plugin-sdk-go v0.250.0 h1:9EBucp9jLqMx2b8NTlOXH+4OuQW
 github.com/grafana/grafana-plugin-sdk-go v0.250.0/go.mod h1:gCGN9kHY3KeX4qyni3+Kead38Q+85pYOrsDcxZp6AIk=
 github.com/grafana/grafana-plugin-sdk-go v0.250.1 h1:cIElucYsy9JZb/9GMXzk0oWJVd3pxuCWCgvPm99UM9w=
 github.com/grafana/grafana-plugin-sdk-go v0.250.1/go.mod h1:gCGN9kHY3KeX4qyni3+Kead38Q+85pYOrsDcxZp6AIk=
+github.com/grafana/grafana-plugin-sdk-go v0.250.2 h1:6Jepiu9V3bMdSPfxDl7bReas5qjcO/xNUMOHZhshgMw=
+github.com/grafana/grafana-plugin-sdk-go v0.250.2/go.mod h1:gCGN9kHY3KeX4qyni3+Kead38Q+85pYOrsDcxZp6AIk=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/athena/macros.go
+++ b/pkg/athena/macros.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/grafana/sqlds/v4"
 	"github.com/pkg/errors"
 	"github.com/viant/toolbox"
@@ -28,12 +29,12 @@ func parseTime(target, format string) string {
 
 func parseTimeGroup(query *sqlutil.Query, args []string) (time.Duration, string, error) {
 	if len(args) < 2 {
-		return 0, "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "macro $__timeGroup needs time column and interval")
+		return 0, "", errorsource.DownstreamError(errors.WithMessagef(sqlds.ErrorBadArgumentCount, "macro $__timeGroup needs time column and interval"), false)
 	}
 
 	interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 	if err != nil {
-		return 0, "", fmt.Errorf("error parsing interval %v", args[1])
+		return 0, "", errorsource.DownstreamError(fmt.Errorf("error parsing interval %v", args[1]), false)
 	}
 
 	timeVar := args[0]
@@ -62,7 +63,7 @@ func macroUnixEpochGroup(query *sqlutil.Query, args []string) (string, error) {
 
 func macroParseTime(query *sqlutil.Query, args []string) (string, error) {
 	if len(args) < 1 {
-		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected at least one argument")
+		return "", errorsource.DownstreamError(errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected at least one argument"), false)
 	}
 
 	var (
@@ -79,7 +80,7 @@ func macroParseTime(query *sqlutil.Query, args []string) (string, error) {
 
 func macroTimeFilter(query *sqlutil.Query, args []string) (string, error) {
 	if len(args) < 1 {
-		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected at least one argument")
+		return "", errorsource.DownstreamError(errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected at least one argument"), false)
 	}
 
 	var (
@@ -99,7 +100,7 @@ func macroTimeFilter(query *sqlutil.Query, args []string) (string, error) {
 
 func macroUnixEpochFilter(query *sqlutil.Query, args []string) (string, error) {
 	if len(args) != 1 {
-		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected one argument")
+		return "", errorsource.DownstreamError(errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected one argument"), false)
 	}
 
 	var (
@@ -140,7 +141,7 @@ func macroRawTimeTo(query *sqlutil.Query, args []string) (string, error) {
 
 func macroDateFilter(query *sqlutil.Query, args []string) (string, error) {
 	if len(args) != 1 {
-		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected 1 argument, received %d", len(args))
+		return "", errorsource.DownstreamError(errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected 1 argument, received %d", len(args)), false)
 	}
 
 	var (

--- a/pkg/athena/macros.go
+++ b/pkg/athena/macros.go
@@ -34,7 +34,7 @@ func parseTimeGroup(query *sqlutil.Query, args []string) (time.Duration, string,
 
 	interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 	if err != nil {
-		return 0, "", errorsource.DownstreamError(fmt.Errorf("error parsing interval %v", args[1]), false)
+		return 0, "", errors.WithMessagef(err, fmt.Sprintf("error parsing interval %v", args[1]))
 	}
 
 	timeVar := args[0]

--- a/pkg/athena/macros.go
+++ b/pkg/athena/macros.go
@@ -34,7 +34,7 @@ func parseTimeGroup(query *sqlutil.Query, args []string) (time.Duration, string,
 
 	interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 	if err != nil {
-		return 0, "", errors.WithMessagef(err, fmt.Sprintf("error parsing interval %v", args[1]))
+		return 0, "", errors.WithMessagef(err, "error parsing interval %v", args[1])
 	}
 
 	timeVar := args[0]


### PR DESCRIPTION
These are user errors, so shouldn't be marked as plugin:
- "macro $__timeGroup needs time column and interval"
- "expected at least one argument"
- "expected one argument"
- "expected 1 argument, received %d"

In line 37
```
return 0, "", errors.WithMessagef(err, fmt.Sprintf("error parsing interval %v", args[1]))
```

I'm passing on the message from plugin-sdk ("Invalid interval", "invalid duration") and marking it downstream there: https://github.com/grafana/grafana-plugin-sdk-go/pull/1088