### PR TITLE
Chore: group dependabot updates and use a weekly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,9 +28,6 @@ updates:
     ignore:
       - dependency-name: "@grafana/e2e*"
     groups:
-      grafana-dependencies:
-        patterns:
-          - '@grafana/*'
       all-dependencies:
         patterns:
           - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,21 +8,29 @@ updates:
   - package-ecosystem: 'gomod'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     ignore:
       - dependency-name: "@grafana/e2e*"
     groups:
-      dependencies:
+      grafana-dependencies:
         patterns:
           - '@grafana/*'
-      dev-dependencies:
+      all-dependencies:
         patterns:
-          - '@grafana/e2e*'
+          - '*'


### PR DESCRIPTION
- Groups updates according to the package ecosystem
- Sets update interval to be weekly (this will be Mondays by default)