### PR TITLE
Prepare release 2.18.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
-      all-dependencies:
+      all-go-dependencies:
         patterns:
           - '*'
   - package-ecosystem: 'github-actions'
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
-      all-dependencies:
+      all-github-action-dependencies:
         patterns:
           - '*'
   - package-ecosystem: 'npm'
@@ -26,8 +26,8 @@ updates:
     schedule:
       interval: 'weekly'
     ignore:
-      - dependency-name: "@grafana/e2e*"
+      - dependency-name: '@grafana/e2e*'
     groups:
-      all-dependencies:
+      all-node-dependencies:
         patterns:
           - '*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,35 @@
 
 - Bump sqlds and grafana-plugin-sdk-go for error source improvements in [#462](https://github.com/grafana/athena-datasource/pull/462)
 - Dependabot updates
+  - @emotion/css from 11.13.4 to 11.13.5
   - @grafana/async-query-data from 0.2.0 to 0.3.0
-  - @grafana/data from 11.2.2 to 11.3.0
+  - @grafana/data from 11.2.2 to 11.3.1
   - @grafana/eslint-config from 7.0.0 to 8.0.0
-  - @grafana/runtime from 11.2.2 to 11.3.0
-  - @grafana/schema from 11.2.2 to 11.3.0
+  - @grafana/experimental from 2.1.2 to 2.1.4
+  - @grafana/runtime from 11.2.2 to 11.3.1
+  - @grafana/schema from 11.2.2 to 11.3.1
+  - @grafana/ui from 11.3.0 to 11.3.1
   - tslib from 2.7.0 to 2.8.1
   - @babel/core from 7.25.8 to 7.26.0
-  - @swc/core from 1.7.35 to 1.9.2
+  - @swc/core from 1.7.35 to 1.9.3
   - @swc/helpers from 0.5.13 to 0.5.15
   - @swc/jest from 0.2.36 to 0.2.37
   - @testing-library/jest-dom from 6.5.0 to 6.6.3
   - @types/jest from 29.5.13 to 29.5.14
   - @types/lodash from 4.17.10 to 4.17.13
-  - @types/node from 22.7.5 to 22.9.0
+  - @types/node from 22.7.5 to 22.9.3
   - cross-spawn from 7.0.3 to 7.0.6
   - cspell from 8.15.2 to 8.16.0
   - eslint-plugin-jsx-a11y from 6.10.0 to 6.10.2
   - lefthook from 1.7.18 to 1.8.4
+  - react-router-dom from 6.28.0 to 7.0.1
   - sass from 1.79.5 to 1.81.0
   - sass-loader from 16.0.2 to 16.0.3
+  - typescript from 5.6.3 to 5.7.2
   - webpack from 5.95.0 to 5.96.1
   - github.com/grafana/grafana-aws-sdk from 0.31.3 to 0.31.4
+  - github.com/grafana/grafana-plugin-sdk-go from 0.259.2 to 0.259.4
+  - github.com/stretchr/testify from 1.9.0 to 1.10.0
 
 ## 2.17.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 2.18.0
+
+- Bump sqlds and grafana-plugin-sdk-go for error source improvements in [#462](https://github.com/grafana/athena-datasource/pull/462)
+- Dependabot updates
+  - @grafana/async-query-data from 0.2.0 to 0.3.0
+  - @grafana/data from 11.2.2 to 11.3.0
+  - @grafana/eslint-config from 7.0.0 to 8.0.0
+  - @grafana/runtime from 11.2.2 to 11.3.0
+  - @grafana/schema from 11.2.2 to 11.3.0
+  - tslib from 2.7.0 to 2.8.1
+  - @babel/core from 7.25.8 to 7.26.0
+  - @swc/core from 1.7.35 to 1.9.2
+  - @swc/helpers from 0.5.13 to 0.5.15
+  - @swc/jest from 0.2.36 to 0.2.37
+  - @testing-library/jest-dom from 6.5.0 to 6.6.3
+  - @types/jest from 29.5.13 to 29.5.14
+  - @types/lodash from 4.17.10 to 4.17.13
+  - @types/node from 22.7.5 to 22.9.0
+  - cross-spawn from 7.0.3 to 7.0.6
+  - cspell from 8.15.2 to 8.16.0
+  - eslint-plugin-jsx-a11y from 6.10.0 to 6.10.2
+  - lefthook from 1.7.18 to 1.8.4
+  - sass from 1.79.5 to 1.81.0
+  - sass-loader from 16.0.2 to 16.0.3
+  - webpack from 5.95.0 to 5.96.1
+  - github.com/grafana/grafana-aws-sdk from 0.31.3 to 0.31.4
+
 ## 2.17.5
 
 - Bugfix: Bump uber/athenadriver to 1.1.15 in #448
@@ -7,33 +34,34 @@
 - Query Editor: Fix field options not loading in #437
 - Chore: Update plugin.json keywords in #434
 - Dependabot updates
- - Bump @types/node from 22.7.2 to 22.7.5
- - Bump @babel/core from 7.25.2 to 7.25.7
- - Bump @emotion/css from 11.13.0 to 11.13.4
- - Updates @grafana/data from 11.2.1 to 11.2.2
- - Updates @grafana/experimental from 2.1.0 to 2.1.2
- - Updates @grafana/runtime from 11.2.1 to 11.2.2
- - Updates @grafana/schema from 11.2.1 to 11.2.2
- - Updates @grafana/ui from 11.2.1 to 11.2.2
- - Updates @grafana/aws-sdk from 0.4.2 to 0.5.0
- - Bump webpack from 5.94.0 to 5.95.0 
- - Bump sass from 1.79.3 to 1.79.5 
- - Bump lefthook from 1.7.17 to 1.7.18
- - Bump github.com/grafana/sqlds/v4 from 4.1.1 to 4.1.2
- - Bump github.com/grafana/grafana-aws-sdk from 0.31.2 to 0.31.3 
- - Bump @types/lodash from 4.17.7 to 4.17.10 
- - Bump @swc/core from 1.7.26 to 1.7.35 (#426)
- - Bump @types/node from 22.5.5 to 22.7.2 (#425)
- - Bump lefthook from 1.7.16 to 1.7.17 (#424)
- - Bump @types/jest from 29.5.12 to 29.5.13 
- - Bump lefthook from 1.7.15 to 1.7.16 
- - Bump sass-loader from 16.0.1 to 16.0.2 
- - Bump cspell from 8.14.2 to 8.15.2 
- - Bump github.com/grafana/grafana-plugin-sdk-go from 0.250.2 to 0.251.0
- - Bump github/combine-prs from 5.1.0 to 5.2.0
- - Bump typescript from 5.6.2 to 5.6.3
+  - Bump @types/node from 22.7.2 to 22.7.5
+  - Bump @babel/core from 7.25.2 to 7.25.7
+  - Bump @emotion/css from 11.13.0 to 11.13.4
+  - Updates @grafana/data from 11.2.1 to 11.2.2
+  - Updates @grafana/experimental from 2.1.0 to 2.1.2
+  - Updates @grafana/runtime from 11.2.1 to 11.2.2
+  - Updates @grafana/schema from 11.2.1 to 11.2.2
+  - Updates @grafana/ui from 11.2.1 to 11.2.2
+  - Updates @grafana/aws-sdk from 0.4.2 to 0.5.0
+  - Bump webpack from 5.94.0 to 5.95.0
+  - Bump sass from 1.79.3 to 1.79.5
+  - Bump lefthook from 1.7.17 to 1.7.18
+  - Bump github.com/grafana/sqlds/v4 from 4.1.1 to 4.1.2
+  - Bump github.com/grafana/grafana-aws-sdk from 0.31.2 to 0.31.3
+  - Bump @types/lodash from 4.17.7 to 4.17.10
+  - Bump @swc/core from 1.7.26 to 1.7.35 (#426)
+  - Bump @types/node from 22.5.5 to 22.7.2 (#425)
+  - Bump lefthook from 1.7.16 to 1.7.17 (#424)
+  - Bump @types/jest from 29.5.12 to 29.5.13
+  - Bump lefthook from 1.7.15 to 1.7.16
+  - Bump sass-loader from 16.0.1 to 16.0.2
+  - Bump cspell from 8.14.2 to 8.15.2
+  - Bump github.com/grafana/grafana-plugin-sdk-go from 0.250.2 to 0.251.0
+  - Bump github/combine-prs from 5.1.0 to 5.2.0
+  - Bump typescript from 5.6.2 to 5.6.3
 
 ## 2.17.4
+
 - Mark errors when interpolating macros errors as downstream in [#410](https://github.com/grafana/athena-datasource/pull/410)
 - Bump github.com/grafana/grafana-plugin-sdk-go from 0.248.0 to 0.250.2 in [#410](https://github.com/grafana/athena-datasource/pull/410)
 - Dependabot updates
@@ -41,13 +69,13 @@
   - Bump @types/node from 22.5.3 to 22.5.5
   - Bump @babel/core from 7.24.7 to 7.25.2
   - Bump @swc/helpers from 0.5.11 to 0.5.13
-  - Bump @testing-library/jest-dom and @types/testing-library__jest-dom 
+  - Bump @testing-library/jest-dom and @types/testing-library\_\_jest-dom
 
 ## 2.17.3
 
 - Update Athena to Amazon Athena
 - fix: don't check slice nilness before length check in [#385](https://github.com/grafana/athena-datasource/pull/385)
-chore: add manual "combine PRs" action in [#386](https://github.com/grafana/athena-datasource/pull/3586)
+- chore: add manual "combine PRs" action in [#386](https://github.com/grafana/athena-datasource/pull/3586)
 - Dependabot updates (some merged via combined PRs):
   - [#352](https://github.com/grafana/athena-datasource/pull/352): Bump github.com/aws/aws-sdk-go from 1.51.31 to 1.55.5
   - [#362](https://github.com/grafana/athena-datasource/pull/362): Bump typescript from 5.4.5 to 5.5.4
@@ -74,7 +102,7 @@ chore: add manual "combine PRs" action in [#386](https://github.com/grafana/athe
   - [#350](https://github.com/grafana/athena-datasource/pull/350): Bump actions/setup-node from 3 to 4
   - [#349](https://github.com/grafana/athena-datasource/pull/349): Bump tibdex/github-app-token from 1.8.0 to 2.1.0
   - [#392](https://github.com/grafana/athena-datasource/pull/392): Bump @swc/helpers from 0.5.11 to 0.5.13
-  
+
 ## 2.17.2
 
 - Bump dependencies in [#347](https://github.com/grafana/athena-datasource/pull/347), [#365](https://github.com/grafana/athena-datasource/pull/365), [#360](https://github.com/grafana/athena-datasource/pull/360), [#361](https://github.com/grafana/athena-datasource/pull/361), [#359](https://github.com/grafana/athena-datasource/pull/359), [#358](https://github.com/grafana/athena-datasource/pull/358), [#357](https://github.com/grafana/athena-datasource/pull/357), [#355](https://github.com/grafana/athena-datasource/pull/355), [#348](https://github.com/grafana/athena-datasource/pull/348), [#351](https://github.com/grafana/athena-datasource/pull/351), [#365](https://github.com/grafana/athena-datasource/pull/365)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "2.17.5",
+  "version": "2.18.0",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Release 2.18.0 and also updated the dependabot config group names so that dependabot PR will include which package ecosystem the PR is for instead of having all of the PRs don't just refer to `all-dependencies`