### PR TITLE
Add PDC support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@grafana/ui": "^11.2.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "semver": "^7.6.3",
     "tslib": "2.8.1"
   },
   "devDependencies": {
@@ -51,6 +52,7 @@
     "@types/lodash": "^4.17.13",
     "@types/node": "^22.9.3",
     "@types/react-router-dom": "^5.2.0",
+    "@types/semver": "^7.5.8",
     "@types/testing-library__jest-dom": "6.0.0",
     "copy-webpack-plugin": "^12.0.2",
     "cspell": "^8.16.0",

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -1,11 +1,12 @@
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings, GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { AthenaDataSourceOptions, AthenaDataSourceSecureJsonData, AthenaDataSourceSettings, defaultKey } from './types';
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
 import { AwsAuthType, ConfigSelect, ConnectionConfig, Divider } from '@grafana/aws-sdk';
 import { selectors } from 'tests/selectors';
 import { ConfigSection } from '@grafana/experimental';
-import { Field, Input, useStyles2 } from '@grafana/ui';
+import { Field, Input, SecureSocksProxySettings, useStyles2 } from '@grafana/ui';
+import { gte } from 'semver';
 import { css } from '@emotion/css';
 
 type Props = DataSourcePluginOptionsEditorProps<AthenaDataSourceOptions, AthenaDataSourceSecureJsonData>;
@@ -104,6 +105,9 @@ export function ConfigEditor(props: Props) {
   return (
     <div className={styles.formStyles}>
       <ConnectionConfig {...props} onOptionsChange={onOptionsChange} externalId={externalId} />
+      {config.secureSocksDSProxyEnabled && gte(config.buildInfo.version, '10.0.0') && (
+        <SecureSocksProxySettings options={props.options} onOptionsChange={onOptionsChange} />
+      )}
       <Divider />
       <ConfigSection title="Athena Details">
         <Field

--- a/yarn.lock
+++ b/yarn.lock
@@ -3242,6 +3242,11 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/semver@^7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"


### PR DESCRIPTION
Fixes https://github.com/grafana/oss-plugin-partnerships/issues/1125

[Instructions for testing PDC locally](https://wiki.grafana-ops.net/w/index.php/Engineering/Grafana/Data_Sources/API_servers/Testing_datasources_with_PDC_Locally)

New secure socks proxy setting added below the region selector in the config page

<img width="484" alt="athena" src="https://github.com/user-attachments/assets/40c5181b-975b-4437-a346-a72b9bf38271" />
