### PR TITLE
Make sure athena error object is not nil

### DIFF
--- a/pkg/athena/api/api_test.go
+++ b/pkg/athena/api/api_test.go
@@ -40,6 +40,7 @@ func TestExecute_InternalServerErrorReturnsQueryFailedInternalStatus(t *testing.
 	expectedErr := &awsds.QueryExecutionError{Cause: awsds.QueryFailedInternal, Err: backend.DownstreamError(fmt.Errorf("%w: %v", api.ExecuteError, athenaclientmock.AthenaInternalServerErrorMock))}
 	assert.Equal(t, err, expectedErr)
 }
+
 func TestExecute__UserErrorReturnsQueryFailedUserErrorStatus(t *testing.T) {
 	c := NewFake(&athenaclientmock.MockAthenaClient{CalledTimesCountDown: 1}, &models.AthenaDataSourceSettings{})
 	_, err := c.Execute(context.Background(), &api.ExecuteQueryInput{Query: athenaclientmock.FAKE_USER_ERROR})
@@ -61,6 +62,13 @@ func Test_Status(t *testing.T) {
 			description:          "success",
 			calledTimesCountDown: 1,
 			finished:             true,
+		},
+		{
+			description:          "error",
+			calledTimesCountDown: 1,
+			status:               athenaclientmock.UNEXPECTED_ERROR,
+			finished:             true,
+			expectedError:        backend.DownstreamError(errors.New(athenaclientmock.UNEXPECTED_ERROR)),
 		},
 		{
 			description:          "error",

--- a/pkg/athena/api/mock/athena-client.go
+++ b/pkg/athena/api/mock/athena-client.go
@@ -12,6 +12,7 @@ import (
 
 const DESCRIBE_STATEMENT_FAILED = "DESCRIBE_STATEMENT_FAILED"
 const DESCRIBE_STATEMENT_SUCCEEDED = "DESCRIBE_STATEMENT_FINISHED"
+const UNEXPECTED_ERROR = "UNEXPECTED_ERROR"
 
 // Define a mock struct to be used in your unit tests of myFunc.
 type MockAthenaClient struct {
@@ -35,7 +36,15 @@ func (m *MockAthenaClient) GetQueryExecutionWithContext(ctx aws.Context, input *
 
 	output := &athena.GetQueryExecutionOutput{}
 	if m.CalledTimesCountDown == 0 {
-		if *input.QueryExecutionId == DESCRIBE_STATEMENT_FAILED {
+		if *input.QueryExecutionId == UNEXPECTED_ERROR {
+			output.QueryExecution = &athena.QueryExecution{
+				Status: &athena.QueryExecutionStatus{
+					State:             aws.String(athena.QueryExecutionStateFailed),
+					StateChangeReason: aws.String(UNEXPECTED_ERROR),
+					AthenaError:       nil,
+				},
+			}
+		} else if *input.QueryExecutionId == DESCRIBE_STATEMENT_FAILED {
 			output.QueryExecution = &athena.QueryExecution{
 				Status: &athena.QueryExecutionStatus{
 					State:             aws.String(athena.QueryExecutionStateFailed),


### PR DESCRIPTION
More context in this thread:https://raintank-corp.slack.com/archives/C06TNNEKAHL/p1741876632895959?thread_ts=1741599530.099189&cid=C06TNNEKAHL
Normally AthenaError error wouldn't have nil objects, so this wouldn't happen, but we can't know the cause until we pass the downstream error. 