### PR TITLE
Github workflows: Don't use hash for grafana actions and add permissions for PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Get secrets from vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           repo_secrets: |
             ACCESS_KEY=e2e:accessKey

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm install --production --prefix ./actions
       - name: Get secrets from vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           repo_secrets: |
             AWS_DS_TOKEN_CREATOR_ID=aws-ds-token-creator:app_id

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      # The "id-token: write" permission is required by "get-vault-secrets" action
+      id-token: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v4

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      # The "id-token: write" permission is required by "get-vault-secrets" action
+      id-token: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v4

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm install --production --prefix ./actions
       - name: Get secrets from vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           repo_secrets: |
             AWS_DS_TOKEN_CREATOR_ID=aws-ds-token-creator:app_id


### PR DESCRIPTION
We exclude grafana/ hashes it in the zizmor config. Also get-vault-secrets needs id-token permission