### PR TITLE
Bump grafana aws sdk to pick up v2 auth fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.3
+- Bump grafana-aws-sdk to pick up v2 auth fix in [#544](https://github.com/grafana/athena-datasource/pull/544)
+
 ## 3.1.2
 
 - Migrate to aws-sdk-go-v2 in [#491](https://github.com/grafana/athena-datasource/pull/491)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/service/athena v1.50.5
 	github.com/google/go-cmp v0.7.0
-	github.com/grafana/grafana-aws-sdk v0.38.3
+	github.com/grafana/grafana-aws-sdk v0.38.4
 	github.com/grafana/grafana-plugin-sdk-go v0.277.0
 	github.com/grafana/sqlds/v4 v4.2.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/grafana/athenadriver v0.0.0-20250110154747-907b6f45eba0 h1:oQcudNcDDz
 github.com/grafana/athenadriver v0.0.0-20250110154747-907b6f45eba0/go.mod h1:OTTXLd7aV7Mt0tMDQMKTAbHtAlWV1SaYk8+U46z4lpE=
 github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6kE/MWfg7s=
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
-github.com/grafana/grafana-aws-sdk v0.38.3 h1:oFw90xwNLt8gYAM5DSKvkquAEh6Y2aljA/8d+QC4CBg=
-github.com/grafana/grafana-aws-sdk v0.38.3/go.mod h1:8b/1HXTszz+1n81ONImzyVB+5LfkotRGFHs8Yp7DQ8Y=
+github.com/grafana/grafana-aws-sdk v0.38.4 h1:gp6WlELScSg71LgmgwJzwc1W+ey+3MdWNLX3eb3j14Y=
+github.com/grafana/grafana-aws-sdk v0.38.4/go.mod h1:8b/1HXTszz+1n81ONImzyVB+5LfkotRGFHs8Yp7DQ8Y=
 github.com/grafana/grafana-plugin-sdk-go v0.277.0 h1:VDU2F4Y5NeRS//ejctdZtsAshrGaEdbtW33FsK0EQss=
 github.com/grafana/grafana-plugin-sdk-go v0.277.0/go.mod h1:mAUWg68w5+1f5TLDqagIr8sWr1RT9h7ufJl5NMcWJAU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
This brings in https://github.com/grafana/grafana-aws-sdk/pull/246, which should fix the reported issues with Workspace IAM Role authentication.

Also prepares for the v3.1.3 release.

Fixes: #541