### PR TITLE
Fix: use user external id if not using assume role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.6
+
+- Fix: use user external id if not using assume role in [#553](https://github.com/grafana/athena-datasource/pull/553)
+
 ## 3.1.5
 
 - Fix: get externalId from grafana config in [#550](https://github.com/grafana/athena-datasource/pull/550)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/service/athena v1.50.5
 	github.com/google/go-cmp v0.7.0
-	github.com/grafana/grafana-aws-sdk v0.38.5
+	github.com/grafana/grafana-aws-sdk v0.38.6
 	github.com/grafana/grafana-plugin-sdk-go v0.277.1
 	github.com/grafana/sqlds/v4 v4.2.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/grafana/athenadriver v0.0.0-20250110154747-907b6f45eba0 h1:oQcudNcDDz
 github.com/grafana/athenadriver v0.0.0-20250110154747-907b6f45eba0/go.mod h1:OTTXLd7aV7Mt0tMDQMKTAbHtAlWV1SaYk8+U46z4lpE=
 github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6kE/MWfg7s=
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
-github.com/grafana/grafana-aws-sdk v0.38.5 h1:qm1S1CamsY9UK1KR014TBW9hberQOWmGPF800wSrAnQ=
-github.com/grafana/grafana-aws-sdk v0.38.5/go.mod h1:LflvMuuX0BNSd1Oe6KcH5CGV/zxm4VrfN/0wLNPKvVc=
+github.com/grafana/grafana-aws-sdk v0.38.6 h1:ROmyvL4yP3DjCchRDuVo2btAOVkNdmn6jrtSmJsC1ZY=
+github.com/grafana/grafana-aws-sdk v0.38.6/go.mod h1:LflvMuuX0BNSd1Oe6KcH5CGV/zxm4VrfN/0wLNPKvVc=
 github.com/grafana/grafana-plugin-sdk-go v0.277.1 h1:CF2pk2Pc/VX0DNBdk1+n3XSL0KvzMEcy6oubN/qdEmY=
 github.com/grafana/grafana-plugin-sdk-go v0.277.1/go.mod h1:2ekE3wh4VyHmvBKP3VBdJNoAK4fD50HLxhlco9FzTwg=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	athenatypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/grafana/athena-datasource/pkg/athena/api/mock"
 	drv "github.com/uber/athenadriver/go"
@@ -56,7 +57,6 @@ func New(ctx context.Context, _ *awsds.SessionCache, settings sqlModels.Settings
 	if region == "" || region == "default" {
 		region = athenaSettings.DefaultRegion
 	}
-	authSettings, _ := awsds.ReadAuthSettingsFromContext(ctx)
 
 	cfg, err := awsauth.NewConfigProvider().GetConfig(ctx, awsauth.Settings{
 		LegacyAuthType:     athenaSettings.AuthType,
@@ -66,7 +66,7 @@ func New(ctx context.Context, _ *awsds.SessionCache, settings sqlModels.Settings
 		CredentialsProfile: athenaSettings.Profile,
 		AssumeRoleARN:      athenaSettings.AssumeRoleARN,
 		Endpoint:           athenaSettings.Endpoint,
-		ExternalID:         authSettings.ExternalID,
+		ExternalID:         athenaSettings.ExternalID,
 		HTTPClient:         httpClient,
 		UserAgent:          "athena",
 	})


### PR DESCRIPTION
Updates for https://github.com/grafana/grafana-aws-sdk/pull/248 , which fetches the grafana assume role external id off the context when we need it, and otherwise use the user setting 