### PR TITLE
Chore: Update CONTRIBUTING.md with release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,4 +72,5 @@ You need to have commit rights to the GitHub repository to publish a release.
 1. Update the version number in the `package.json` file.
 2. Update the `CHANGELOG.md` with the changes contained in the release.
 3. Commit the changes to master and push to GitHub.
-4. Follow the Drone release process that you can find [here](https://github.com/grafana/integrations-team/wiki/Plugin-Release-Process#drone-release-process)
+4. Follow the release process that you can find [here](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#cd_1)
+


### PR DESCRIPTION
I forgot to update the release instructions in the github actions migration PR 