### PR TITLE
chore(deps): update go version to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/athena-datasource
 
-go 1.25.7
+go 1.26.1
 
 replace github.com/uber/athenadriver => github.com/grafana/athenadriver v0.0.0-20250616140009-9083f49e325c
 


### PR DESCRIPTION
- Resolve [GHSA-p77j-4mvh-x3m3](https://nvd.nist.gov/vuln/detail/CVE-2026-33186) critical vulnerability (affects gRPC-Go versions before v1.79.3
- Resolve [CVE-2026-25679](https://nvd.nist.gov/vuln/detail/CVE-2026-24679) high vulnerability (URL parsing in Go stdlib pre `1.25.8`)