### PR TITLE
Add session token handling for auth service support

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -90,6 +90,7 @@
     "jackspeak",
     "dompurify",
     "zizmor",
+    "AKIAIOSFODNN",
     "npmPreapprovedPackages"
   ]
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,3 +18,4 @@ services:
       ACCESS_KEY: ${ACCESS_KEY}
       SECRET_KEY: ${SECRET_KEY}
       GF_FEATURE_TOGGLES_splashScreen: "false"
+      GF_FEATURE_TOGGLES_dashboardNewLayouts: "false"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,3 +17,4 @@ services:
     environment:
       ACCESS_KEY: ${ACCESS_KEY}
       SECRET_KEY: ${SECRET_KEY}
+      GF_FEATURE_TOGGLES_splashScreen: "false"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.28.5",
     "@eslint/eslintrc": "^3.3.1",
     "@grafana/eslint-config": "^8.2.0",
-    "@grafana/plugin-e2e": "^2.1.14",
+    "@grafana/plugin-e2e": "^3.4.12",
     "@grafana/tsconfig": "^2.0.1",
     "@playwright/test": "1.55.1",
     "@stylistic/eslint-plugin-ts": "^4.2.0",

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -34,6 +34,8 @@ type Client interface {
 
 var _ Client = &mock.MockAthenaClient{}
 
+var newAWSConfigProvider = awsauth.NewConfigProvider
+
 type API struct {
 	Client   Client
 	settings *models.AthenaDataSourceSettings
@@ -58,10 +60,11 @@ func New(ctx context.Context, settings sqlModels.Settings) (api.AWSAPI, error) {
 		region = athenaSettings.DefaultRegion
 	}
 
-	cfg, err := awsauth.NewConfigProvider().GetConfig(ctx, awsauth.Settings{
+	cfg, err := newAWSConfigProvider().GetConfig(ctx, awsauth.Settings{
 		LegacyAuthType:     athenaSettings.AuthType,
 		AccessKey:          athenaSettings.AccessKey,
 		SecretKey:          athenaSettings.SecretKey,
+		SessionToken:       athenaSettings.SessionToken,
 		Region:             region,
 		CredentialsProfile: athenaSettings.Profile,
 		AssumeRoleARN:      athenaSettings.AssumeRoleARN,

--- a/pkg/athena/api/api_test.go
+++ b/pkg/athena/api/api_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	athenaclientmock "github.com/grafana/athena-datasource/pkg/athena/api/mock"
 	"github.com/grafana/athena-datasource/pkg/athena/models"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsauth"
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-aws-sdk/pkg/sql/api"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/sqlds/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConnection_Execute(t *testing.T) {
@@ -197,6 +199,37 @@ func TestConnection_ListColumnsForTable(t *testing.T) {
 	if !cmp.Equal(expected, res) {
 		t.Errorf("unexpected result: %v", cmp.Diff(expected, res))
 	}
+}
+
+type spyConfigProvider struct {
+	captured awsauth.Settings
+}
+
+func (s *spyConfigProvider) GetConfig(_ context.Context, settings awsauth.Settings) (aws.Config, error) {
+	s.captured = settings
+	return aws.Config{}, nil
+}
+
+func TestNew_passesSessionToken(t *testing.T) {
+	spy := &spyConfigProvider{}
+	origProvider := newAWSConfigProvider
+	newAWSConfigProvider = func() awsauth.ConfigProvider { return spy }
+	t.Cleanup(func() { newAWSConfigProvider = origProvider })
+
+	s := &models.AthenaDataSourceSettings{}
+	err := s.Load(backend.DataSourceInstanceSettings{
+		JSONData: []byte(`{"authType": "keys", "defaultRegion": "us-east-1"}`),
+		DecryptedSecureJSONData: map[string]string{
+			"accessKey":    "AKIAIOSFODNN7EXAMPLE",
+			"secretKey":    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			"sessionToken": "AQoDYXdzEJr//test-session-token",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = New(context.Background(), s)
+	require.NoError(t, err)
+	assert.Equal(t, "AQoDYXdzEJr//test-session-token", spy.captured.SessionToken)
 }
 
 func Test_WorkgroupEngineSupportsResultReuse(t *testing.T) {

--- a/pkg/athena/models/settings.go
+++ b/pkg/athena/models/settings.go
@@ -44,6 +44,7 @@ func (s *AthenaDataSourceSettings) Load(config backend.DataSourceInstanceSetting
 
 	s.AccessKey = config.DecryptedSecureJSONData["accessKey"]
 	s.SecretKey = config.DecryptedSecureJSONData["secretKey"]
+	s.SessionToken = config.DecryptedSecureJSONData["sessionToken"]
 
 	s.Config = config
 

--- a/pkg/athena/models/settings_test.go
+++ b/pkg/athena/models/settings_test.go
@@ -6,8 +6,27 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-aws-sdk/pkg/sql/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/sqlds/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestLoad_sessionToken(t *testing.T) {
+	s := &AthenaDataSourceSettings{}
+	config := backend.DataSourceInstanceSettings{
+		JSONData: []byte(`{"authType": "keys", "defaultRegion": "us-east-1"}`),
+		DecryptedSecureJSONData: map[string]string{
+			"accessKey":    "AKIAIOSFODNN7EXAMPLE",
+			"secretKey":    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			"sessionToken": "AQoDYXdzEJr//test-session-token",
+		},
+	}
+
+	err := s.Load(config)
+	require.NoError(t, err)
+	assert.Equal(t, "AQoDYXdzEJr//test-session-token", s.SessionToken)
+}
 
 func TestConnection_getRegionKey(t *testing.T) {
 	tests := []struct {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,14 +1470,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/e2e-selectors@npm:^12.2.0-255920":
-  version: 12.2.0
-  resolution: "@grafana/e2e-selectors@npm:12.2.0"
+"@grafana/e2e-selectors@npm:13.0.0-23624974663":
+  version: 13.0.0-23624974663
+  resolution: "@grafana/e2e-selectors@npm:13.0.0-23624974663"
   dependencies:
     semver: "npm:^7.7.0"
     tslib: "npm:2.8.1"
     typescript: "npm:5.9.2"
-  checksum: 10c0/ab94a4dbb2299f439bc798e198b86291091958bfe858d3cdfbf7fbde9c3d5a03265e320158c12dd950a8fed07deb635d2f3636bdc00c14d1d802efd91010593d
+  checksum: 10c0/714095fbf1932c49a923027e0d6d5e6d89f7dd06070e512716f58a7a2241eeac10b24ef9427b5ff5a21b2e4df43240ed2532676197e5daa75e7828b044e7bc54
   languageName: node
   linkType: hard
 
@@ -1519,17 +1519,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-e2e@npm:^2.1.14":
-  version: 2.1.14
-  resolution: "@grafana/plugin-e2e@npm:2.1.14"
+"@grafana/plugin-e2e@npm:^3.4.12":
+  version: 3.4.12
+  resolution: "@grafana/plugin-e2e@npm:3.4.12"
   dependencies:
-    "@grafana/e2e-selectors": "npm:^12.2.0-255920"
+    "@grafana/e2e-selectors": "npm:13.0.0-23624974663"
     semver: "npm:^7.5.4"
     uuid: "npm:^13.0.0"
     yaml: "npm:^2.3.4"
   peerDependencies:
+    "@axe-core/playwright": ^4.11.1
     "@playwright/test": ^1.52.0
-  checksum: 10c0/86d08b06583585e3a1e09cd404f2f7d59bccc480020718cf913989ae5051115fb41c6169d8e2e7b7d07e25c5a0748e77ce979b8aa16cd2f8f94c3ab18537f696
+  peerDependenciesMeta:
+    "@axe-core/playwright":
+      optional: true
+  checksum: 10c0/b87340d2cb04bcbcaf7676d61f8f990fd26ba1d8f53cfb922e89a4751ede29bbe61021d770d3a9ebdf4500fe404fe6512ddea03be4d1c08ee15d22e9e5a376e7
   languageName: node
   linkType: hard
 
@@ -7323,7 +7327,7 @@ __metadata:
     "@grafana/aws-sdk": "npm:0.10.2"
     "@grafana/data": "npm:^12.0.2"
     "@grafana/eslint-config": "npm:^8.2.0"
-    "@grafana/plugin-e2e": "npm:^2.1.14"
+    "@grafana/plugin-e2e": "npm:^3.4.12"
     "@grafana/plugin-ui": "npm:^0.13.0"
     "@grafana/runtime": "npm:^12.0.2"
     "@grafana/schema": "npm:12.0.2"


### PR DESCRIPTION
To enable Grafana Assume Role via the auth service in Grafana Cloud we need to make use of the passed-in SessionToken.

This also fixes some unrelated e2e test failures.