### PR TITLE
fix: add .UTC() to macroTimeFilter for consistent timezone handling

### DIFF
--- a/pkg/athena/macros.go
+++ b/pkg/athena/macros.go
@@ -88,8 +88,8 @@ func macroTimeFilter(query *sqlutil.Query, args []string) (string, error) {
 	var (
 		column     = args[0]
 		timeFormat = ""
-		from       = query.TimeRange.From.Format(goTimestampFormat)
-		to         = query.TimeRange.To.Format(goTimestampFormat)
+		from       = query.TimeRange.From.UTC().Format(goTimestampFormat)
+		to         = query.TimeRange.To.UTC().Format(goTimestampFormat)
 	)
 
 	if len(args) > 1 {


### PR DESCRIPTION
## Summary

Adds missing `.UTC()` calls to `macroTimeFilter` in `pkg/athena/macros.go` for consistent timezone handling across all time macros.

## Problem

The `macroTimeFilter` function (implementing `$__timeFilter`) was the only time macro that did not normalize time values to UTC before formatting. This caused incorrect TIMESTAMP boundaries when the Grafana time picker timezone was set to a non-UTC timezone, producing wrong query results for UTC-partitioned data in Athena.

All other time macros (`$__timeFrom`, `$__timeTo`, `$__rawTimeFrom`, `$__rawTimeTo`, `$__unixEpochFilter`, `$__dateFilter`) correctly call `.UTC()` before formatting.

## Fix

```diff
-       from       = query.TimeRange.From.Format(goTimestampFormat)
-       to         = query.TimeRange.To.Format(goTimestampFormat)
+       from       = query.TimeRange.From.UTC().Format(goTimestampFormat)
+       to         = query.TimeRange.To.UTC().Format(goTimestampFormat)
```

## Testing

- Existing unit tests pass (they use `&time.Location{}` which is equivalent to UTC, so the fix doesn't change their behavior)
- Manual testing: set time picker to IST (UTC+5:30), run query with `$__timeFilter` against UTC-partitioned Athena data — results now match Athena Console and CloudWatch Logs Insights

Fixes #844