### PR TITLE
Forward per-datasource grafanaExternalId for Assume Role

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@grafana/async-query-data": "0.4.3",
     "@grafana/aws-sdk": "0.12.0",
     "@grafana/data": "13.1.1",
-    "@grafana/e2e-selectors": "13.1.1",
+    "@grafana/e2e-selectors": "13.2.0-30594044109",
     "@grafana/i18n": "13.1.1",
     "@grafana/plugin-ui": "0.17.3",
     "@grafana/runtime": "13.1.1",
@@ -102,5 +102,8 @@
     "node": ">=24",
     "yarn": ">=4.14.0"
   },
-  "packageManager": "yarn@4.15.0"
+  "packageManager": "yarn@4.15.0",
+  "resolutions": {
+    "@grafana/e2e-selectors": "13.2.0-30594044109"
+  }
 }

--- a/pkg/athena/api/api.go
+++ b/pkg/athena/api/api.go
@@ -61,17 +61,19 @@ func New(ctx context.Context, settings sqlModels.Settings) (api.AWSAPI, error) {
 	}
 
 	cfg, err := newAWSConfigProvider().GetConfig(ctx, awsauth.Settings{
-		LegacyAuthType:     athenaSettings.AuthType,
-		AccessKey:          athenaSettings.AccessKey,
-		SecretKey:          athenaSettings.SecretKey,
-		SessionToken:       athenaSettings.SessionToken,
-		Region:             region,
-		CredentialsProfile: athenaSettings.Profile,
-		AssumeRoleARN:      athenaSettings.AssumeRoleARN,
-		Endpoint:           athenaSettings.Endpoint,
-		ExternalID:         athenaSettings.ExternalID,
-		HTTPClient:         httpClient,
-		UserAgent:          "athena",
+		LegacyAuthType:             athenaSettings.AuthType,
+		AccessKey:                  athenaSettings.AccessKey,
+		SecretKey:                  athenaSettings.SecretKey,
+		SessionToken:               athenaSettings.SessionToken,
+		Region:                     region,
+		CredentialsProfile:         athenaSettings.Profile,
+		AssumeRoleARN:              athenaSettings.AssumeRoleARN,
+		Endpoint:                   athenaSettings.Endpoint,
+		ExternalID:                 athenaSettings.ExternalID,
+		GrafanaExternalID:          athenaSettings.GrafanaExternalID,
+		UsePerDatasourceExternalID: athenaSettings.UsePerDatasourceExternalID,
+		HTTPClient:                 httpClient,
+		UserAgent:                  "athena",
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/athena/api/api_test.go
+++ b/pkg/athena/api/api_test.go
@@ -232,6 +232,28 @@ func TestNew_passesSessionToken(t *testing.T) {
 	assert.Equal(t, "AQoDYXdzEJr//test-session-token", spy.captured.SessionToken)
 }
 
+func TestNew_passesGrafanaExternalIDFields(t *testing.T) {
+	spy := &spyConfigProvider{}
+	origProvider := newAWSConfigProvider
+	newAWSConfigProvider = func() awsauth.ConfigProvider { return spy }
+	t.Cleanup(func() { newAWSConfigProvider = origProvider })
+
+	usePerDS := true
+	s := &models.AthenaDataSourceSettings{}
+	err := s.Load(backend.DataSourceInstanceSettings{
+		JSONData: []byte(`{"authType": "grafana_assume_role", "defaultRegion": "us-east-1", "assumeRoleArn": "arn:aws:iam::123456789012:role/test", "grafanaExternalId": "stackABC-dsUid1", "usePerDatasourceExternalId": true}`),
+	})
+	require.NoError(t, err)
+	s.UsePerDatasourceExternalID = &usePerDS
+	s.GrafanaExternalID = "stackABC-dsUid1"
+
+	_, err = New(context.Background(), s)
+	require.NoError(t, err)
+	assert.Equal(t, "stackABC-dsUid1", spy.captured.GrafanaExternalID)
+	require.NotNil(t, spy.captured.UsePerDatasourceExternalID)
+	assert.True(t, *spy.captured.UsePerDatasourceExternalID)
+}
+
 func Test_WorkgroupEngineSupportsResultReuse(t *testing.T) {
 	assert.True(t, workgroupEngineSupportsResultReuse("Athena engine version 3"))
 	assert.False(t, workgroupEngineSupportsResultReuse("Athena engine version 2"))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,24 +1783,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/e2e-selectors@npm:13.1.0-25644485979":
-  version: 13.1.0-25644485979
-  resolution: "@grafana/e2e-selectors@npm:13.1.0-25644485979"
+"@grafana/e2e-selectors@npm:13.2.0-30594044109":
+  version: 13.2.0-30594044109
+  resolution: "@grafana/e2e-selectors@npm:13.2.0-30594044109"
   dependencies:
     semver: "npm:^7.7.0"
-    tslib: "npm:2.8.1"
-    typescript: "npm:6.0.2"
-  checksum: 10c0/4333578ebd1e072a869376e1a31de222ba8678a01cbe6970d27ce483de8954289f08a3f6bdd59bbf6a1fb4f35c08a8a89440b0992bb2e1348eadc648e8a44992
-  languageName: node
-  linkType: hard
-
-"@grafana/e2e-selectors@npm:13.1.1":
-  version: 13.1.1
-  resolution: "@grafana/e2e-selectors@npm:13.1.1"
-  dependencies:
-    semver: "npm:^7.7.0"
-    typescript: "npm:6.0.2"
-  checksum: 10c0/b6c2a62acc42de9c767fa3073de07042ba2a0902dc98735e099fab359e3027e85e7dd38d8e25ccaff081da8a56ad74a89f0f84c493fb2fda69077cf81ca9a428
+  checksum: 10c0/7397a6e009573074df11430e883cfc4f75045d8627eac3c6d93da7a345382c855ce60d120ab80bf6ad3e390ea2d00e84edeed1b27022ea027a71110ab8e78f03
   languageName: node
   linkType: hard
 
@@ -7697,7 +7685,7 @@ __metadata:
     "@grafana/async-query-data": "npm:0.4.3"
     "@grafana/aws-sdk": "npm:0.12.0"
     "@grafana/data": "npm:13.1.1"
-    "@grafana/e2e-selectors": "npm:13.1.1"
+    "@grafana/e2e-selectors": "npm:13.2.0-30594044109"
     "@grafana/eslint-config": "npm:^8.2.0"
     "@grafana/i18n": "npm:13.1.1"
     "@grafana/plugin-e2e": "npm:3.10.0"
@@ -12960,16 +12948,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:6.0.2":
-  version: 6.0.2
-  resolution: "typescript@npm:6.0.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/4b860b0bf87cc0fee0f66d8ef2640b5a8a8a8c74d1129adb82e389e5f97124383823c47946bef8a73ede371461143a3aa8544399d2133c7b2e4f07e81860af7f
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
@@ -12977,16 +12955,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
-  version: 6.0.2
-  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/49f0b84fc6ca55653e77752b8a61beabc09ee3dae5d965c31596225aa6ef213c5727b1d2e895b900416dc603854ba0872ac4a812c2a4ed6793a601f9c675de02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Forward `GrafanaExternalID` and `UsePerDatasourceExternalID` from datasource settings into `awsauth.Settings` so Grafana Assume Role STS can use the per-datasource external ID when enabled.
- Companion to grafana/grafana#129737 (CloudWatch monorepo) / grafana-cloudwatch-datasource#582.

## Context
Grafana already mints/preserves `jsonData.grafanaExternalId` and ConnectionConfig UI is available via `@grafana/aws-sdk` 0.12.0. This wires Athena to pass those fields at assume-role time.

## Test plan
- [x] `go test ./pkg/athena/api/ -run TestNew_passesGrafanaExternalIDFields`
- [ ] With `awsAssumeRolePerDatasourceExternalId` enabled, create an Athena DS with Grafana Assume Role and confirm STS uses `{stackId}-{dsUid}` when `usePerDatasourceExternalId` is true
- [ ] With the flag/toggle unset/false, confirm stack external ID is still used even if a dormant per-DS ID is stored