### PR TITLE
Prepare release 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.1
+
+- Bump `@grafana/aws-sdk` to 0.12.1 so Grafana Assume Role external IDs display before save on Cloud in [#882](https://github.com/grafana/athena-datasource/pull/882)
+
 ## 3.3.0
 
 - Forward per-datasource grafanaExternalId for Assume Role in [#880](https://github.com/grafana/athena-datasource/pull/880)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@grafana/async-query-data": "0.4.3",
-    "@grafana/aws-sdk": "0.12.0",
+    "@grafana/aws-sdk": "0.12.1",
     "@grafana/data": "13.1.1",
     "@grafana/e2e-selectors": "13.2.0-30594044109",
     "@grafana/i18n": "13.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/ConfigEditor.test.tsx
+++ b/src/ConfigEditor.test.tsx
@@ -188,4 +188,40 @@ describe('ConfigEditor', () => {
     await userEvent.click(instructionsButton);
     expect(screen.queryByText('External Id is currently unavailable')).toBeInTheDocument();
   });
+
+  it('shows stack external ID from config.namespace when /externalId returns empty', async () => {
+    // @grafana/aws-sdk 0.12.1+ falls back to Cloud-style config.namespace when the
+    // plugin's /externalId fetch has nothing yet — so instructions are not "unavailable".
+    runtime.config.featureToggles.awsDatasourcesTempCredentials = true;
+    // @ts-expect-error not yet on published FeatureToggles
+    runtime.config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    runtime.config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    runtime.config.namespace = 'stacks-12345';
+
+    setUpMockBackendServer({
+      put: jest.fn().mockResolvedValue({ datasource: {} }),
+      post: jest.fn().mockResolvedValue({ externalId: '' }),
+    });
+
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          type: 'grafana-athena-datasource',
+          jsonData: {
+            ...props.options.jsonData,
+            authType: AwsAuthType.GrafanaAssumeRole,
+          },
+        }}
+      />
+    );
+
+    const instructionsButton = await screen.findByRole('button', {
+      name: /How to create an IAM role for grafana to assume/i,
+    });
+    await userEvent.click(instructionsButton);
+    expect(screen.getByText('12345')).toBeInTheDocument();
+    expect(screen.queryByText('External Id is currently unavailable')).not.toBeInTheDocument();
+  });
 });

--- a/src/ConfigEditor.test.tsx
+++ b/src/ConfigEditor.test.tsx
@@ -189,9 +189,9 @@ describe('ConfigEditor', () => {
     expect(screen.queryByText('External Id is currently unavailable')).toBeInTheDocument();
   });
 
-  it('shows stack external ID from config.namespace when /externalId returns empty', async () => {
-    // @grafana/aws-sdk 0.12.1+ falls back to Cloud-style config.namespace when the
-    // plugin's /externalId fetch has nothing yet — so instructions are not "unavailable".
+  it('mints per-datasource external ID from config.namespace when /externalId returns empty', async () => {
+    // @grafana/aws-sdk 0.12.1+ uses Cloud-style config.namespace as the stack ID when the
+    // plugin's /externalId fetch is empty, then mints {stack}-{uid} for per-DS mode.
     runtime.config.featureToggles.awsDatasourcesTempCredentials = true;
     // @ts-expect-error not yet on published FeatureToggles
     runtime.config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
@@ -203,25 +203,46 @@ describe('ConfigEditor', () => {
       post: jest.fn().mockResolvedValue({ externalId: '' }),
     });
 
-    render(
-      <ConfigEditor
-        {...props}
-        options={{
-          ...props.options,
-          type: 'grafana-athena-datasource',
-          jsonData: {
-            ...props.options.jsonData,
+    const onOptionsChange = jest.fn();
+    const initialOptions = {
+      ...props.options,
+      type: 'grafana-athena-datasource',
+      uid: 'athena-id',
+      // No authType yet — ConnectionConfig defaults to GAR and mints the per-DS ID.
+      jsonData: {
+        ...props.options.jsonData,
+        authType: undefined,
+      },
+    };
+
+    const { rerender } = render(<ConfigEditor {...props} options={initialOptions} onOptionsChange={onOptionsChange} />);
+
+    await waitFor(() =>
+      expect(onOptionsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uid: 'athena-id',
+          jsonData: expect.objectContaining({
             authType: AwsAuthType.GrafanaAssumeRole,
-          },
-        }}
-      />
+            usePerDatasourceExternalId: true,
+            grafanaExternalId: '12345-athena-id',
+          }),
+        })
+      )
     );
+
+    const mintedOptions = onOptionsChange.mock.calls.find(
+      (call) => call[0]?.jsonData?.grafanaExternalId === '12345-athena-id'
+    )?.[0];
+    rerender(<ConfigEditor {...props} options={mintedOptions} onOptionsChange={onOptionsChange} />);
 
     const instructionsButton = await screen.findByRole('button', {
       name: /How to create an IAM role for grafana to assume/i,
     });
     await userEvent.click(instructionsButton);
-    expect(screen.getByText('12345')).toBeInTheDocument();
+    expect(screen.getByText('12345-athena-id')).toBeInTheDocument();
+    expect(screen.getByText(/unique to this data source/i)).toBeInTheDocument();
     expect(screen.queryByText('External Id is currently unavailable')).not.toBeInTheDocument();
+    // Stack-only fallback must not win once the per-DS ID is minted.
+    expect(screen.queryByText('12345', { exact: true })).not.toBeInTheDocument();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,12 +1736,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/aws-sdk@npm:0.12.0":
-  version: 0.12.0
-  resolution: "@grafana/aws-sdk@npm:0.12.0"
+"@grafana/aws-sdk@npm:0.12.1":
+  version: 0.12.1
+  resolution: "@grafana/aws-sdk@npm:0.12.1"
   peerDependencies:
     "@grafana/plugin-ui": ">=0.14.0"
-  checksum: 10c0/ddaebf62d9f49d89bc5e1d4eba85c7131c92583ad1e382a0e836fcb93e363de2c76929ecb2ccd7ee37518b5b5a3263415988b840affea6b0af510f0294a7a306
+  checksum: 10c0/bda7becad21c72ac27d3308b3d4cd069b84cb3bcede8ce7d13746d7e9e06f8eb92a171c21d6cbeb372caac13e89144a2b2658b2f34bc1df13436d568249e1894
   languageName: node
   linkType: hard
 
@@ -7683,7 +7683,7 @@ __metadata:
     "@emotion/css": "npm:11.13.5"
     "@eslint/eslintrc": "npm:^3.3.1"
     "@grafana/async-query-data": "npm:0.4.3"
-    "@grafana/aws-sdk": "npm:0.12.0"
+    "@grafana/aws-sdk": "npm:0.12.1"
     "@grafana/data": "npm:13.1.1"
     "@grafana/e2e-selectors": "npm:13.2.0-30594044109"
     "@grafana/eslint-config": "npm:^8.2.0"


### PR DESCRIPTION
## Summary
- Bump `@grafana/aws-sdk` to **0.12.1** so Grafana Assume Role external IDs display before save on Cloud (namespace fallback from [grafana-aws-sdk-react#501](https://github.com/grafana/grafana-aws-sdk-react/pull/501))
- Add ConfigEditor regression test for minted per-datasource external ID
- Bump version to **3.3.1** and update `CHANGELOG.md`

## Test plan
- [x] `yarn build`
- [x] `mage -v`
- [x] `yarn test:ci`
- [ ] CI green on this PR
- [ ] After merge, run the [CD release process on enghub](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#cd_1)