### PR TITLE
fix: interpolate connection args in applyTemplateVariables

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -14,10 +14,11 @@ interface TestContext {
 describe('AthenaDatasource', () => {
   const ctx: TestContext = {} as TestContext;
   const mockGetVariables = jest.fn().mockReturnValue([]);
+  const mockReplace = jest.fn((target: string) => target.replace('$testVar', 'replaced'));
 
   jest.spyOn(runtime, 'getTemplateSrv').mockImplementation(() => ({
     getVariables: mockGetVariables,
-    replace: jest.fn(),
+    replace: mockReplace,
     containsTemplate: jest.fn(),
     updateTimeRange: jest.fn(),
   }));
@@ -152,42 +153,66 @@ describe('AthenaDatasource', () => {
     });
   });
 
-  describe('When building queries', () => {
-    jest.spyOn(runtime, 'getTemplateSrv').mockImplementation(() => ({
-      getVariables: mockGetVariables,
-      replace: (target: string) => target.replace('$testVar', 'replaced'),
-      containsTemplate: jest.fn(),
-      updateTimeRange: jest.fn(),
-    }));
-
-    it('should return query unchanged if there are no template variables', async () => {
-      const queries = ctx.ds.buildQuery(queryRequest, queryRequest.targets);
+  describe('When interpolating variables in queries', () => {
+    it('should return the query unchanged if there are no template variables', () => {
+      const queries = ctx.ds.interpolateVariablesInQueries([defaultQuery], {});
 
       expect(queries).toHaveLength(1);
-      expect(queries[0]).toBe(defaultQuery);
+      expect(queries[0]).toEqual(defaultQuery);
     });
 
-    it('should not add additional properties to the query', async () => {
-      const request = { ...queryRequest, targets: [{ ...defaultQuery, column: undefined }] };
-      const queries = ctx.ds.buildQuery(request, request.targets);
+    it('should not add additional properties to the query', () => {
+      const query = { ...defaultQuery, table: undefined, column: undefined };
+      const queries = ctx.ds.interpolateVariablesInQueries([query], {});
 
       expect(queries).toHaveLength(1);
-      expect(queries[0]).toEqual({ ...defaultQuery, column: undefined });
+      expect(queries[0]).toStrictEqual(query);
     });
 
-    it('should return query with template variables replaced', async () => {
-      queryRequest.targets = [
-        {
-          ...defaultQuery,
-          connectionArgs: {
-            ...defaultQuery.connectionArgs,
-            region: '$testVar',
+    it('should replace template variables in the connection args, table and column', () => {
+      const queries = ctx.ds.interpolateVariablesInQueries(
+        [
+          {
+            ...defaultQuery,
+            connectionArgs: {
+              region: '$testVar',
+              catalog: '$testVar',
+              database: '$testVar',
+            },
+            table: '$testVar',
+            column: '$testVar',
           },
-        },
-      ];
-      const queries = ctx.ds.buildQuery(queryRequest, queryRequest.targets);
+        ],
+        {}
+      );
+
       expect(queries).toHaveLength(1);
-      expect(queries[0].connectionArgs.region).toEqual('replaced');
+      expect(queries[0].connectionArgs).toEqual({
+        region: 'replaced',
+        catalog: 'replaced',
+        database: 'replaced',
+      });
+      expect(queries[0].table).toEqual('replaced');
+      expect(queries[0].column).toEqual('replaced');
+    });
+
+    it('should not mutate the original query', () => {
+      const query: AthenaQuery = {
+        ...defaultQuery,
+        connectionArgs: { region: '$testVar', catalog: '$testVar', database: '$testVar' },
+        table: '$testVar',
+        column: '$testVar',
+      };
+
+      ctx.ds.interpolateVariablesInQueries([query], {});
+
+      expect(query.connectionArgs).toEqual({
+        region: '$testVar',
+        catalog: '$testVar',
+        database: '$testVar',
+      });
+      expect(query.table).toEqual('$testVar');
+      expect(query.column).toEqual('$testVar');
     });
   });
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -52,8 +52,17 @@ export class DataSource extends DatasourceWithAsyncBackend<AthenaQuery, AthenaDa
     return target.hide !== true && filterSQLQuery(target);
   }
 
-  applyTemplateVariables = (query: AthenaQuery, scopedVars: ScopedVars) =>
-    applySQLTemplateVariables(query, scopedVars, getTemplateSrv);
+  applyTemplateVariables = (query: AthenaQuery, scopedVars: ScopedVars): AthenaQuery => ({
+    ...applySQLTemplateVariables(query, scopedVars, () => this.templateSrv),
+    connectionArgs: {
+      ...query.connectionArgs,
+      region: this.templateSrv.replace(query.connectionArgs?.region, scopedVars),
+      catalog: this.templateSrv.replace(query.connectionArgs?.catalog, scopedVars),
+      database: this.templateSrv.replace(query.connectionArgs?.database, scopedVars),
+    },
+    table: query.table ? this.templateSrv.replace(query.table, scopedVars) : undefined,
+    column: query.column ? this.templateSrv.replace(query.column, scopedVars) : undefined,
+  });
 
   getVariables = () => this.templateSrv.getVariables().map((v) => `$${v.name}`);
 
@@ -87,25 +96,10 @@ export class DataSource extends DatasourceWithAsyncBackend<AthenaQuery, AthenaDa
 
   getWorkgroupEngineVersion = () => this.postResource<string>('workgroupEngineVersion', { workgroup: this.workgroup });
 
-  buildQuery(options: DataQueryRequest<AthenaQuery>, queries: AthenaQuery[]): AthenaQuery[] {
-    const updatedQueries = queries.map((query) => {
-      query.connectionArgs.region = this.templateSrv.replace(query.connectionArgs.region, options.scopedVars);
-      query.connectionArgs.catalog = this.templateSrv.replace(query.connectionArgs.catalog, options.scopedVars);
-      query.connectionArgs.database = this.templateSrv.replace(query.connectionArgs.database, options.scopedVars);
-      query.table = query.table ? this.templateSrv.replace(query.table, options.scopedVars) : undefined;
-      query.column = query.column ? this.templateSrv.replace(query.column, options.scopedVars) : undefined;
-      return query;
-    });
-
-    return updatedQueries;
-  }
-
   query(options: DataQueryRequest<AthenaQuery>): Observable<DataQueryResponse> {
     options = cloneDeep(options);
 
-    const queries = options.targets.filter((item) => item.hide !== true && item.rawSQL);
-
-    options.targets = this.buildQuery(options, queries);
+    options.targets = options.targets.filter((item) => item.hide !== true && item.rawSQL);
 
     return super.query(options);
   }


### PR DESCRIPTION
## What

Interpolate `connectionArgs` (`region` / `catalog` / `database`), `table` and `column` in `applyTemplateVariables` instead of only in `buildQuery`. `buildQuery` is removed, Grafana's base `interpolateVariablesInQueries` now covers both the dashboard and Explore paths via `applyTemplateVariables`.

## Why
closes #886 

## Testing

Unit tests added in `src/datasource.test.ts`.

Manually verified on Grafana 12.2.0 with a dashboard panel whose Region is a template variable, against both a `main` build and this branch. Opening that panel in Explore, and creating an alert rule from it, both previously carried the raw `${var}` and now resolve.

**Explorer:**

Before:
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/e72ba6c0-8283-4765-8f69-db143ac1ef2e" />

After:
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/efb64d65-116b-4575-a114-44f850722f2a" />


**New alert rule from the panel:**

Before:
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/29c53aa8-daf4-4aaa-b32b-fe9a1b928932" />

After:
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/435e51ee-9bda-4e55-8518-022c2a62c1f7" />

