### PR TITLE
feat(config): allow custom Workgroup and Database values

### DIFF
--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -144,6 +144,7 @@ export function ConfigEditor(props: Props) {
             label={selectors.components.ConfigEditor.database.input}
             dependencies={[props.options.jsonData.catalog || '']}
             saveOptions={saveOptions}
+            allowCustomValue
           />
         </Field>
         <Field
@@ -159,6 +160,7 @@ export function ConfigEditor(props: Props) {
             fetch={fetchWorkgroups}
             label={selectors.components.ConfigEditor.workgroup.input}
             saveOptions={saveOptions}
+            allowCustomValue
           />
         </Field>
         <Field


### PR DESCRIPTION
## Summary
- Enable `allowCustomValue` on the Workgroup and Database `ConfigSelect`s in the Athena config editor.
- Users with restrictive IAM (no `athena:ListWorkGroups` / `glue:GetDatabases`) can type known values instead of relying on list APIs.

Fixes #803

## Test plan
- [ ] Open Athena datasource settings without list permissions and type a custom Workgroup/Database
- [ ] With list permissions, confirm existing dropdown selection still works and custom values can still be entered