### PR TITLE
fix: bump local dev Grafana version to match plugin dependencies

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     platform: 'linux/amd64'
     build:
       args:
-        grafana_version: ${GRAFANA_VERSION:-10.3.6}
+        grafana_version: ${GRAFANA_VERSION:-12.2.0}
     ports:
       - 3000:3000/tcp
     environment:


### PR DESCRIPTION
## Summary

`docker-compose.yaml` pinned the local dev/test `GRAFANA_VERSION` default to `10.3.6`, three major versions behind the `@grafana/data`, `@grafana/ui`, and `@grafana/runtime` `13.1.1` packages the frontend is built against — and below the plugin's own declared `grafanaDependency` of `>=10.4.0-0`.

This version mismatch caused the query editor to crash on mount with a React error (`Minified React error #130`) in the local dev environment, reproducible with any datasource (including one with valid, real AWS credentials) — i.e. unrelated to credentials or backend data.

Bumping the default to `12.2.0` resolves the crash. This matches the default already used by sibling plugins pinned to the exact same `@grafana/data` `13.1.1` version (e.g. `grafana-tempo-datasource`, `grafana-cloudwatch-datasource`), which don't override the shared scaffold's `.config/docker-compose-base.yaml` default at all.

## Test plan

- [x] `docker compose up --build -d` with the new default, confirmed `GET /api/health` reports `"version": "12.2.0"`
- [x] Query editor renders without the "An unexpected error happened" crash (previously reproducible in both Explore and dashboard panel-edit contexts)
- [x] `npx playwright test tests/e2e/queryEditor.spec.ts` now fails with a sensible timeout waiting on `getByText('cloudtrail')` (no local AWS credentials configured), rather than the prior React crash