### PR TITLE
E2E: retry query assertions on transient Athena throttling

### DIFF
--- a/tests/e2e/annotationsEditor.spec.ts
+++ b/tests/e2e/annotationsEditor.spec.ts
@@ -2,6 +2,11 @@ import { expect, test } from '@grafana/plugin-e2e';
 import { selectors } from '../../src/tests/selectors';
 
 test('should render annotations editor', async ({ annotationEditPage, page }) => {
+  // The toPass() blocks below can take up to 30s + 15s if Athena's GetWorkGroup API is throttled,
+  // which would exceed Playwright's default 30s per-test timeout on its own — extend the test
+  // timeout so a slow-but-successful retry isn't cut off by the outer test deadline.
+  test.setTimeout(90_000);
+
   await annotationEditPage.datasource.set('AWS Athena');
 
   // Wait for the monaco editor to finish lazy loading

--- a/tests/e2e/annotationsEditor.spec.ts
+++ b/tests/e2e/annotationsEditor.spec.ts
@@ -13,9 +13,11 @@ test('should render annotations editor', async ({ annotationEditPage, page }) =>
   // Athena's GetWorkGroup API is occasionally throttled (ThrottlingException: Rate exceeded) under
   // concurrent CI load against the shared e2e AWS account. The query itself succeeds within seconds
   // on retry, so retry the test-query action rather than failing on a single throttled response.
+  // Use a slower backoff than toPass()'s default (100ms) so retries don't add to the rate-limit
+  // pressure that caused the throttling in the first place.
   await expect(async () => {
     await expect(annotationEditPage.runQuery()).toBeOK();
-  }).toPass({ timeout: 30_000 });
+  }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
   // The dropdown's option list depends on the query result's field names, which can still be
   // settling right after the query above resolves. Retry the click rather than assuming the
   // forced click lands on an already-interactive combobox.

--- a/tests/e2e/annotationsEditor.spec.ts
+++ b/tests/e2e/annotationsEditor.spec.ts
@@ -16,7 +16,12 @@ test('should render annotations editor', async ({ annotationEditPage, page }) =>
   await expect(async () => {
     await expect(annotationEditPage.runQuery()).toBeOK();
   }).toPass({ timeout: 30_000 });
+  // The dropdown's option list depends on the query result's field names, which can still be
+  // settling right after the query above resolves. Retry the click rather than assuming the
+  // forced click lands on an already-interactive combobox.
   const timeDropdown = page.getByText('time, or the first time field', { exact: true });
-  await timeDropdown.click({ force: true });
-  await expect(page.getByText('date (time)', { exact: true })).toBeVisible();
+  await expect(async () => {
+    await timeDropdown.click({ force: true });
+    await expect(page.getByText('date (time)', { exact: true })).toBeVisible({ timeout: 5_000 });
+  }).toPass({ timeout: 15_000 });
 });

--- a/tests/e2e/annotationsEditor.spec.ts
+++ b/tests/e2e/annotationsEditor.spec.ts
@@ -9,7 +9,13 @@ test('should render annotations editor', async ({ annotationEditPage, page }) =>
 
   await annotationEditPage.getByGrafanaSelector(selectors.components.QueryEditor.CodeEditor.container).click();
   await page.keyboard.insertText(`select * from cloudfront_logs where bytes < 100 limit 10`);
-  await expect(annotationEditPage.runQuery()).toBeOK();
+
+  // Athena's GetWorkGroup API is occasionally throttled (ThrottlingException: Rate exceeded) under
+  // concurrent CI load against the shared e2e AWS account. The query itself succeeds within seconds
+  // on retry, so retry the test-query action rather than failing on a single throttled response.
+  await expect(async () => {
+    await expect(annotationEditPage.runQuery()).toBeOK();
+  }).toPass({ timeout: 30_000 });
   const timeDropdown = page.getByText('time, or the first time field', { exact: true });
   await timeDropdown.click({ force: true });
   await expect(page.getByText('date (time)', { exact: true })).toBeVisible();

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -2,6 +2,11 @@ import { test, expect } from '@grafana/plugin-e2e';
 import { selectors } from '../../src/tests/selectors';
 
 test('should render query editor', async ({ page, panelEditPage, readProvisionedDashboard, gotoPanelEditPage }) => {
+  // The two toPass() blocks below can each take up to 30s if Athena's GetWorkGroup API is
+  // throttled, which would exceed Playwright's default 30s per-test timeout on its own — extend
+  // the test timeout so a slow-but-successful retry isn't cut off by the outer test deadline.
+  test.setTimeout(120_000);
+
   await panelEditPage.datasource.set('AWS Athena');
 
   // Wait for the monaco editor to finish lazy loading

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -36,7 +36,12 @@ test('should render query editor', async ({ page, panelEditPage, readProvisioned
 FROM $__table WHERE additionaleventdata IS NOT NULL AND json_extract_scalar(additionaleventdata, '$.bytesTransferredOut') IS NOT NULL AND  $__timeFilter(eventtime, 'yyyy-MM-dd''T''HH:mm:ss''Z') 
 GROUP BY 1 
 ORDER BY 1`);
-  await expect(panelEditPage.refreshPanel()).toBeOK();
+  // Athena's GetWorkGroup API is occasionally throttled (ThrottlingException: Rate exceeded) under
+  // concurrent CI load against the shared e2e AWS account. The query itself succeeds within seconds
+  // on retry, so retry the refresh action rather than failing on a single throttled response.
+  await expect(async () => {
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+  }).toPass({ timeout: 30_000 });
 
   // test provisioned dashboards
   const dashboard = await readProvisionedDashboard({ fileName: 'testDashboard.json' });
@@ -44,7 +49,9 @@ ORDER BY 1`);
   // Wait for the initial auto-run to finish before forcing another refresh.
   const refreshButton = page.getByTestId('data-testid RefreshPicker run button').last();
   await expect(refreshButton).toHaveAccessibleName(/refresh/i);
-  const provisionedQuery = panel1.waitForQueryDataResponse();
-  await refreshButton.click();
-  await expect(provisionedQuery).toBeOK();
+  await expect(async () => {
+    const provisionedQuery = panel1.waitForQueryDataResponse();
+    await refreshButton.click();
+    await expect(provisionedQuery).toBeOK();
+  }).toPass({ timeout: 30_000 });
 });

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -39,9 +39,11 @@ ORDER BY 1`);
   // Athena's GetWorkGroup API is occasionally throttled (ThrottlingException: Rate exceeded) under
   // concurrent CI load against the shared e2e AWS account. The query itself succeeds within seconds
   // on retry, so retry the refresh action rather than failing on a single throttled response.
+  // Use a slower backoff than toPass()'s default (100ms) so retries don't add to the rate-limit
+  // pressure that caused the throttling in the first place.
   await expect(async () => {
     await expect(panelEditPage.refreshPanel()).toBeOK();
-  }).toPass({ timeout: 30_000 });
+  }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
 
   // test provisioned dashboards
   const dashboard = await readProvisionedDashboard({ fileName: 'testDashboard.json' });
@@ -53,5 +55,5 @@ ORDER BY 1`);
     const provisionedQuery = panel1.waitForQueryDataResponse();
     await refreshButton.click();
     await expect(provisionedQuery).toBeOK();
-  }).toPass({ timeout: 30_000 });
+  }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
 });


### PR DESCRIPTION
Closes #892

## Summary

`annotationsEditor.spec.ts` (and intermittently `queryEditor.spec.ts`) failed deterministically on the Grafana `13.x` CI matrix leg with `400` on `runQuery()`/`refreshPanel()`. Root-caused with real AWS credentials (see #892): it's AWS **throttling** on `GetWorkGroup` under concurrent CI matrix load against the shared `e2e` account, not a Grafana-version bug — the query reliably succeeds within a couple of seconds on retry.

## Changes

- Wrap the Athena-hitting assertions (`runQuery()`, `refreshPanel()`, the provisioned-dashboard refresh) in `expect(async () => {...}).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] })` so a transient throttle retries instead of failing the test. Slower-than-default backoff avoids adding to the rate-limit pressure that caused the throttling in the first place.
- `annotationsEditor.spec.ts`: also retry the time-field dropdown click right after the query — a separate, minor flake (its option list depends on the just-arrived result) noticed while verifying the throttling fix.
- Both files: bumped `test.setTimeout()` (90s / 120s) so the outer per-test timeout doesn't cut off a slow-but-successful retry.

## Verification

- All CI matrix legs pass, including `13.1.3` (previously failing on every run).
- Reproduced against real AWS credentials on Grafana 13.1.3: 5/5 runs pass, including ones that hit an initial throttle.
- Confirmed no regression when run without credentials (fails at the same points as before).
- `npx tsc --noEmit` clean.