### PR TITLE
Release 3.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.3.4
+
+- Fix CVEs by bumping backend dependencies (grpc, golang.org/x/crypto, AWS SDK) in [#902](https://github.com/grafana/athena-datasource/pull/902)
+- Fix CVEs by bumping transitive `fast-uri` to 3.1.7 in [#903](https://github.com/grafana/athena-datasource/pull/903)
+- Chore: Use npm as package manager in [#899](https://github.com/grafana/athena-datasource/pull/899)
+
 ## 3.3.3
 
 - Updated grafana-plugin-sdk-go version to fix boolean bug in [#897](https://github.com/grafana/athena-datasource/pull/897)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-athena-datasource",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8011,7 +8011,9 @@
       "version": "1.0.0"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-athena-datasource",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Use Amazon Athena with Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Summary
- Prepare plugin version **3.3.4**.
- Bump transitive `fast-uri` from 3.1.5 to 3.1.7 via natural npm re-resolution (`package-lock.json` only).
- Includes backend CVE/dependency updates from #902 (already on main) and the npm package-manager switch from #899.

| Package | From | To | Strategy | Severities | CVEs |
| --- | --- | --- | --- | --- | --- |
| fast-uri | 3.1.5 | 3.1.7 | natural | HIGH | CVE-2026-76172, CVE-2026-75975, CVE-2026-75931, CVE-2026-75899 |

Tracks remaining frontend findings from [grafana/data-sources#1851](https://github.com/grafana/data-sources/issues/1851).

## Test plan
- [x] `npm run test:ci` (33 passed)
- [x] `npm run build`
- [x] `mage -v` (binaries report version 3.3.4)
- [ ] CI on this PR
- [ ] After merge, run the [plugin CD release process](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#cd_1)